### PR TITLE
Wikiの差分をGitで管理できるようにする, closes #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ composer install
 
 ## Git support
 
-You can commit and push wiki diffs to your Git repository.
+You can commit and push wiki diffs to your git repository.
 
 ```
 # clone your git repository in data/

--- a/README.md
+++ b/README.md
@@ -70,8 +70,12 @@ $ composer install
 You can commit and push wiki diffs to your Git repository.
 
 ```
+# clone your git repository in data/
 $ cd data
 $ git remote add git@github.com:hoge/fuga.git
+
+# install git library and change settings
 $ cd ../kona3engine
+$ composer install
 $ sed -i -e 's/defC("KONA3_GIT_ENABLED", false);/defC("KONA3_GIT_ENABLED", true);/g' index.inc.php
 ```

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ $ composer install
 You can commit and push wiki diffs to your git repository.
 
 ```
-# clone your git repository in data/
+# set your remote repository in data/
 $ cd data
-$ git remote add git@github.com:hoge/fuga.git
+$ git remote add origin git@github.com:hoge/fuga.git
 
 # install git library and change settings
 $ cd ../kona3engine

--- a/README.md
+++ b/README.md
@@ -64,3 +64,14 @@ text text text text
 $ cd kona3engine
 $ composer install
 ```
+
+## Git support
+
+You can commit and push wiki diffs to your Git repository.
+
+```
+$ cd data
+$ git remote add git@github.com:hoge/fuga.git
+$ cd ../kona3engine
+$ sed -i -e 's/defC("KONA3_GIT_ENABLED", false);/defC("KONA3_GIT_ENABLED", true);/g' index.inc.php
+```

--- a/kona3engine/action/edit.inc.php
+++ b/kona3engine/action/edit.inc.php
@@ -109,8 +109,6 @@ function kona3_trywrite(&$txt, &$a_hash, $i_mode) {
   require_once dirname(dirname(__FILE__)) . '/vendor/autoload.php';
   global $kona3conf, $page;
 
-  $branch = $kona3conf["git.branch"];
-  $remote_repository = $kona3conf["git.remote_repository"];
   $edit_txt = kona3param('edit_txt', '');
   $a_hash_frm = kona3param('a_hash', '');
   $fname = kona3getWikiFile($page);
@@ -155,15 +153,19 @@ function kona3_trywrite(&$txt, &$a_hash, $i_mode) {
   }
   file_put_contents($fname, $edit_txt);
 
-  $repo = new Cz\Git\GitRepository(dirname($fname));
+  if ($kona3conf["git.enabled"]) {
+    $branch = $kona3conf["git.branch"];
+    $remote_repository = $kona3conf["git.remote_repository"];
+    $repo = new Cz\Git\GitRepository(dirname($fname));
 
-  if ($repo->getCurrentBranchName() != $branch) {
-    $repo->checkout($branch);
+    if ($repo->getCurrentBranchName() != $branch) {
+      $repo->checkout($branch);
+    }
+
+    $repo->addFile($fname);
+    $repo->commit("Update $page from Konawiki3");
+    $repo->push($remote_repository, array($branch));
   }
-
-  $repo->addFile($fname);
-  $repo->commit("Update $page from Konawiki3");
-  $repo->push($remote_repository, array($branch));
 
   // result
   if ($i_mode == "ajax") {

--- a/kona3engine/composer.json
+++ b/kona3engine/composer.json
@@ -1,5 +1,6 @@
 {
     "require": {
-        "cebe/markdown": "^1.2"
+        "cebe/markdown": "^1.2",
+        "czproject/git-php": "^3.17"
     }
 }

--- a/kona3engine/index.inc.php
+++ b/kona3engine/index.inc.php
@@ -52,6 +52,9 @@ function setDefConfig() {
   defC("KONA3_DIR_SKIN",       KONA3_DIR_PUBLIC."/skin");
   defC("KONA3_DIR_PUB",        KONA3_DIR_PUBLIC."/pub");
   defC("KONA3_DIR_CACHE",      KONA3_DIR_PUBLIC."/cache");
+  // git
+  defC("KONA3_GIT_BRANCH", "master");
+  defC("KONA3_GIT_REMOTE_REPOSITORY", "origin");
   //
   defC("KONA3_URI_ATTACH",     "./attach");
   defC("KONA3_URI_DATA",       "./data");
@@ -93,6 +96,10 @@ function setDefConfig() {
   $kona3conf["url.pub"]     = KONA3_URI_PUB;
   $kona3conf["path.max.mkdir"] = 3; // max level dir under path.data (disallow = 0)
   $kona3conf["para_enabled_br"] = true;
+
+  // git
+  $kona3conf["git.branch"] = KONA3_GIT_BRANCH;
+  $kona3conf["git.remote_repository"] = KONA3_GIT_REMOTE_REPOSITORY;
 
   // options
   defC("KONA3_PARTS_COUNTCHAR", true);

--- a/kona3engine/index.inc.php
+++ b/kona3engine/index.inc.php
@@ -53,6 +53,7 @@ function setDefConfig() {
   defC("KONA3_DIR_PUB",        KONA3_DIR_PUBLIC."/pub");
   defC("KONA3_DIR_CACHE",      KONA3_DIR_PUBLIC."/cache");
   // git
+  defC("KONA3_GIT_ENABLED", false);
   defC("KONA3_GIT_BRANCH", "master");
   defC("KONA3_GIT_REMOTE_REPOSITORY", "origin");
   //
@@ -98,8 +99,12 @@ function setDefConfig() {
   $kona3conf["para_enabled_br"] = true;
 
   // git
-  $kona3conf["git.branch"] = KONA3_GIT_BRANCH;
-  $kona3conf["git.remote_repository"] = KONA3_GIT_REMOTE_REPOSITORY;
+  $kona3conf["git.enabled"] = KONA3_GIT_ENABLED;
+
+  if ($kona3conf["git.enabled"]) {
+      $kona3conf["git.branch"] = KONA3_GIT_BRANCH;
+      $kona3conf["git.remote_repository"] = KONA3_GIT_REMOTE_REPOSITORY;
+  }
 
   // options
   defC("KONA3_PARTS_COUNTCHAR", true);


### PR DESCRIPTION
ref. #3 

Wikiを編集した際の差分を自動的にGitリポジトリにcommit, pushできるようにします。
これにより、Wiki利用者の利便性を損ねることなく差分を管理できるようになります。