### PR TITLE
gitコマンドがインストールされていない場合、gitでの差分管理を無効化する #3

### DIFF
--- a/kona3engine/index.inc.php
+++ b/kona3engine/index.inc.php
@@ -99,7 +99,7 @@ function setDefConfig() {
   $kona3conf["para_enabled_br"] = true;
 
   // git
-  $kona3conf["git.enabled"] = KONA3_GIT_ENABLED;
+  $kona3conf["git.enabled"] = !is_null(shell_exec("which git")) && KONA3_GIT_ENABLED;
 
   if ($kona3conf["git.enabled"]) {
       $kona3conf["git.branch"] = KONA3_GIT_BRANCH;


### PR DESCRIPTION
ref. #3 

gitコマンドがインストールされていない場合、gitでの差分管理を無効にします。