### PR TITLE
環境構築時にGitのインストールチェックを行うよう修正, closes #7

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,16 +79,7 @@ You can commit and push wiki diffs to your git repository.
 $ cd data
 $ git remote add origin git@github.com:hoge/fuga.git
 
-# install git library and change settings
+# run setup script
 $ cd ../kona3engine
-$ composer install
+$ bash enable_git_support.sh
 ```
-
-And set ``KONA3_GIT_ENABLED`` to TRUE in ``konawiki3.ini.php`` or ``kona3engine/index.inc.php``.
-
-```
-$ sed -i -e 's/defC("KONA3_GIT_ENABLED", false);/defC("KONA3_GIT_ENABLED", true);/g' index.inc.php
-```
-
-
-

--- a/kona3engine/enable_git_support.sh
+++ b/kona3engine/enable_git_support.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ $(which git) != "" ]]
+then
+    composer install
+    sed -i -e 's/defC("KONA3_GIT_ENABLED", false);/defC("KONA3_GIT_ENABLED", true);/g' index.inc.php
+fi

--- a/kona3engine/index.inc.php
+++ b/kona3engine/index.inc.php
@@ -100,7 +100,7 @@ function setDefConfig() {
   $kona3conf["para_enabled_br"] = true;
 
   // git
-  $kona3conf["git.enabled"] = !is_null(shell_exec("which git")) && KONA3_GIT_ENABLED;
+  $kona3conf["git.enabled"] = KONA3_GIT_ENABLED;
 
   if ($kona3conf["git.enabled"]) {
       $kona3conf["git.branch"] = KONA3_GIT_BRANCH;


### PR DESCRIPTION
ref. #7 

Git関連のセットアップ (Gitのインストールチェック, ライブラリインストール, 設定変更) をシェルスクリプト化することで、Gitのインストールチェックがレンダリングの度に行われないようにします。