### PR TITLE
gitが入っていない場合の処理を追加 #7

### DIFF
--- a/kona3engine/enable_git_support.sh
+++ b/kona3engine/enable_git_support.sh
@@ -4,4 +4,6 @@ if [[ $(which git) != "" ]]
 then
     composer install
     sed -i -e 's/defC("KONA3_GIT_ENABLED", false);/defC("KONA3_GIT_ENABLED", true);/g' index.inc.php
+else
+    echo "Please install git and re-run this script."
 fi


### PR DESCRIPTION
ref. #7 

Gitを有効化するスクリプトの中でGitが入っていない場合の処理が記述されていなかったので追加します。