### PR TITLE
なでしこのエディタがIE11で動かない問題の修正

### DIFF
--- a/kona3engine/plugins/nako3/lib.inc.php
+++ b/kona3engine/plugins/nako3/lib.inc.php
@@ -111,6 +111,10 @@ function nako3_make_script_tag(&$nako3) {
       'src'   => 'https://cdn.jsdelivr.net/npm/chart.js@2.9.3/dist/Chart.min.js',
       'async' => TRUE,
     ),
+    array(
+      'src' => 'https://unpkg.com/mocha/mocha.js',
+      'async' => TRUE,
+    )
   );
   // スクリプトタグを生成
   $include_js = '';

--- a/kona3engine/plugins/nako3/tpl-js-edit.html
+++ b/kona3engine/plugins/nako3/tpl-js-edit.html
@@ -8,7 +8,7 @@ const ace_editors = {}
 
 function ace_editor_init(pid) {
     if (navigator.nako3 === undefined) {
-        setTimeout(() => { ace_editor_init(pid) }, 100);
+        setTimeout(function() { ace_editor_init(pid) }, 100);
         return
     }
     ace_editors[pid] = navigator.nako3.setupEditor("ace_editor" + pid);


### PR DESCRIPTION
https://github.com/kujirahand/nadesiko3/pull/794 の変更もないとbigintのリテラルのエラーが出ます。