### PR TITLE
Implement Dark Mode (Issue #154)

### DIFF
--- a/kona3engine/kona3conf.inc.php
+++ b/kona3engine/kona3conf.inc.php
@@ -193,6 +193,7 @@ function kona3conf_setHeaderFooter()
         kona3getResourceURL('pure-min.css'),
         kona3getResourceURL('grids-responsive-min.css'),
         kona3getResourceURL('kona3def.css', TRUE), // default style
+        kona3getResourceURL('darkmode.css', TRUE), // dark mode styles
         kona3getSkinURL('kona3.css', TRUE), // skin style
         kona3getSkinURL('drawer.css', TRUE),
     ]);

--- a/kona3engine/resource/darkmode.css
+++ b/kona3engine/resource/darkmode.css
@@ -266,3 +266,14 @@ body.dark-theme #wikiedit .desc {
   color: #aaa !important;
 }
 
+/* login bar in dark mode */
+body.dark-theme .kona3_login_bar {
+  background-color: #121212 !important;
+  color: #e0e0e0 !important;
+}
+
+body.dark-theme .kona3_login_bar a {
+  color: #3793ef !important;
+}
+
+

--- a/kona3engine/resource/darkmode.css
+++ b/kona3engine/resource/darkmode.css
@@ -1,0 +1,199 @@
+/* Dark Mode Override for KonaWiki3 */
+
+body.dark-theme {
+  background-color: #121212 !important;
+  color: #e0e0e0 !important;
+}
+
+/* layout & header */
+body.dark-theme #kona3_layout_header {
+  background-color: #1e1e1e !important;
+  border-bottom: 1px solid #333 !important;
+}
+
+body.dark-theme #kona3_header_title a {
+  color: #3793ef !important;
+}
+
+body.dark-theme #kona3_header_title .pagename {
+  color: #aaa !important;
+}
+
+/* main content headings */
+body.dark-theme #kona3_main h1 {
+  background-color: #1a1a2e !important;
+  border-bottom: solid 1px #444 !important;
+  color: #e0e0ff !important;
+}
+
+body.dark-theme #kona3_main h2 {
+  border-top: solid 1px #444 !important;
+  border-bottom: solid 1px #444 !important;
+  color: #d0d0ff !important;
+}
+
+body.dark-theme #kona3_main h3 {
+  border-bottom: dotted 1px #444 !important;
+  color: #c0c0ff !important;
+}
+
+body.dark-theme #kona3_main h4,
+body.dark-theme #kona3_main h5,
+body.dark-theme #kona3_main h6 {
+  border-bottom: solid 1px #333 !important;
+  color: #b0b0b0 !important;
+}
+
+/* links */
+body.dark-theme #kona3_main a:link,
+body.dark-theme #kona3_main a:active,
+body.dark-theme #kona3_main a:visited {
+  color: #3793ef !important;
+}
+
+body.dark-theme #kona3_main a:hover {
+  background-color: #333 !important;
+  color: #fff !important;
+}
+
+/* tables */
+body.dark-theme #kona3_main table {
+  color: #e0e0e0 !important;
+}
+
+body.dark-theme #kona3_main table tbody {
+  border-left: 1px solid #444 !important;
+  border-top: 1px solid #444 !important;
+}
+
+body.dark-theme #kona3_main table th {
+  background-color: #2a2a2a !important;
+  border-bottom: 1px solid #444 !important;
+  border-right: 1px solid #444 !important;
+  color: #d0d0ff !important;
+}
+
+body.dark-theme #kona3_main table td {
+  background-color: #1a1a1a !important;
+  border-bottom: 1px solid #444 !important;
+  border-right: 1px solid #444 !important;
+  color: #e0e0e0 !important;
+}
+
+/* forms and inputs */
+body.dark-theme input,
+body.dark-theme textarea,
+body.dark-theme select,
+body.dark-theme button {
+  background-color: #222 !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #555 !important;
+}
+
+body.dark-theme input[type="submit"],
+body.dark-theme button {
+  background-color: #333 !important;
+  cursor: pointer;
+}
+
+body.dark-theme input[type="submit"]:hover,
+body.dark-theme button:hover {
+  background-color: #444 !important;
+}
+
+/* wikimessage & panels */
+body.dark-theme #wikimessage .bodypad {
+  background-color: #1e1e1e !important;
+}
+
+body.dark-theme #wikimessage .box {
+  background-color: #1a1a2e !important;
+}
+
+body.dark-theme #wikimessage .box_border {
+  border: 1px solid #444 !important;
+}
+
+/* drawer/hamburger list menu in dark mode */
+body.dark-theme #drawer_wrapper nav.menuitems ul li {
+  background-color: #222 !important;
+  border-bottom: 1px dotted #333 !important;
+}
+
+body.dark-theme #drawer_wrapper nav.menuitems ul li a {
+  color: #bbb !important;
+}
+
+body.dark-theme #drawer_wrapper nav.menuitems ul li a:hover {
+  color: #fff !important;
+}
+
+/* pre / code / syntax highlighting */
+body.dark-theme pre,
+body.dark-theme code,
+body.dark-theme .mathjax,
+body.dark-theme .filecode {
+  background-color: #1a1a1a !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #333 !important;
+}
+
+/* plugins comment */
+body.dark-theme .plugin_comment .plugin_title {
+  background-color: #1a1a2e !important;
+  color: #e0e0ff !important;
+}
+
+body.dark-theme .plugin_comment .comment_log {
+  border-top: 1px dotted #444 !important;
+  border-left: 4px solid #555 !important;
+  border-bottom: 1px solid #444 !important;
+}
+
+body.dark-theme .plugin_comment .comment_log .comment_body {
+  font-size: 0.8em;
+  padding: 4px;
+}
+
+body.dark-theme .plugin_comment .comment_log .comment_title {
+  border-bottom: 1px dotted #444 !important;
+  color: #888 !important;
+}
+
+body.dark-theme .plugin_comment form {
+  border-bottom: 1px solid #444 !important;
+  border-left: 1px solid #444 !important;
+}
+
+/* todo plugin */
+body.dark-theme #kona3_main .todo {
+  background-color: #1b3d1b !important;
+  color: #8ce68c !important;
+}
+
+/* side bar & navi */
+body.dark-theme #wikinavi .navipad {
+  background-color: #1a1a2e !important;
+}
+
+body.dark-theme #wikinavi h1,
+body.dark-theme #wikinavi h2,
+body.dark-theme #wikinavi h3,
+body.dark-theme #wikinavi h4,
+body.dark-theme #wikinavi h5,
+body.dark-theme #wikinavi h6,
+body.dark-theme #wikisidebar h1,
+body.dark-theme #wikisidebar h2,
+body.dark-theme #wikisidebar h3,
+body.dark-theme #wikisidebar h4,
+body.dark-theme #wikisidebar h5,
+body.dark-theme #wikisidebar h6 {
+  background-color: #1e1e3f !important;
+  color: #e0e0ff !important;
+}
+
+body.dark-theme #kona3_menubar h1,
+body.dark-theme #kona3_menubar h2,
+body.dark-theme #kona3_menubar h3 {
+  border-bottom: dotted 1px #444 !important;
+}

--- a/kona3engine/resource/darkmode.css
+++ b/kona3engine/resource/darkmode.css
@@ -197,3 +197,72 @@ body.dark-theme #kona3_menubar h2,
 body.dark-theme #kona3_menubar h3 {
   border-bottom: dotted 1px #444 !important;
 }
+
+/* edit mode specific dark mode overrides */
+body.dark-theme #wikiedit {
+  background-color: #1a1a2e !important;
+}
+
+body.dark-theme textarea#edit_txt {
+  background-color: #222 !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #555 !important;
+}
+
+body.dark-theme #wikiedit input[type="submit"],
+body.dark-theme #wikiedit input[type="button"],
+body.dark-theme #wikiedit button,
+body.dark-theme #recover_div a,
+body.dark-theme #wikiedit input#outline_btn {
+  background-color: #333 !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #555 !important;
+}
+
+body.dark-theme #wikiedit input[type="submit"]:hover,
+body.dark-theme #wikiedit input[type="button"]:hover,
+body.dark-theme #wikiedit button:hover,
+body.dark-theme #recover_div a:hover,
+body.dark-theme #wikiedit input#outline_btn:hover {
+  background-color: #444 !important;
+  color: #fff !important;
+}
+
+body.dark-theme #wikiedit input[disabled="true"],
+body.dark-theme #wikiedit button:disabled {
+  background-color: #222 !important;
+  color: #666 !important;
+  border: 1px solid #333 !important;
+  cursor: not-allowed;
+}
+
+body.dark-theme #wikiedit #edit_counter,
+body.dark-theme #wikiedit #edit_info {
+  background-color: #1a1a2e !important;
+  color: #aaa !important;
+}
+
+body.dark-theme #ai_output_area {
+  background-color: #1a1a2e !important;
+}
+
+body.dark-theme #ai_output_area .ai_block {
+  background-color: #222 !important;
+  color: #e0e0e0 !important;
+  border: 1px solid #555 !important;
+}
+
+body.dark-theme #wikiedit .block2 {
+  background-color: #222 !important;
+  border: 1px solid #555 !important;
+  color: #e0e0e0 !important;
+}
+
+body.dark-theme #wikiedit .block2 a {
+  color: #3793ef !important;
+}
+
+body.dark-theme #wikiedit .desc {
+  color: #aaa !important;
+}
+

--- a/kona3engine/resource/drawer.js
+++ b/kona3engine/resource/drawer.js
@@ -48,20 +48,32 @@ qq(function(){
       const body = qq('body');
       if (body.hasClass('dark-theme')) {
         body.removeClass('dark-theme');
-        localStorage.setItem('kona3_theme', 'light');
-        themeToggle.html('🌙 Dark Mode');
+        try {
+          localStorage.setItem('kona3_theme', 'light');
+        } catch (err) {
+          console.warn("Storage access failed:", err);
+        }
+        themeToggle.text('🌙 Dark Mode');
+        themeToggle.attr('aria-pressed', 'false');
       } else {
         body.addClass('dark-theme');
-        localStorage.setItem('kona3_theme', 'dark');
-        themeToggle.html('☀️ Light Mode');
+        try {
+          localStorage.setItem('kona3_theme', 'dark');
+        } catch (err) {
+          console.warn("Storage access failed:", err);
+        }
+        themeToggle.text('☀️ Light Mode');
+        themeToggle.attr('aria-pressed', 'true');
       }
     });
 
     // 初期状態のボタン表示調整
     if (qq('body').hasClass('dark-theme')) {
-      themeToggle.html('☀️ Light Mode');
+      themeToggle.text('☀️ Light Mode');
+      themeToggle.attr('aria-pressed', 'true');
     } else {
-      themeToggle.html('🌙 Dark Mode');
+      themeToggle.text('🌙 Dark Mode');
+      themeToggle.attr('aria-pressed', 'false');
     }
   }
   

--- a/kona3engine/resource/drawer.js
+++ b/kona3engine/resource/drawer.js
@@ -40,4 +40,29 @@ qq(function(){
   btn.click(toggleMenu);
   win.click(closeMenu);
   
+  // ダークモード切り替え
+  const themeToggle = qq('#dark_mode_toggle');
+  if (themeToggle) {
+    themeToggle.click(function(e) {
+      if (e) { e.preventDefault(); }
+      const body = qq('body');
+      if (body.hasClass('dark-theme')) {
+        body.removeClass('dark-theme');
+        localStorage.setItem('kona3_theme', 'light');
+        themeToggle.html('🌙 Dark Mode');
+      } else {
+        body.addClass('dark-theme');
+        localStorage.setItem('kona3_theme', 'dark');
+        themeToggle.html('☀️ Light Mode');
+      }
+    });
+
+    // 初期状態のボタン表示調整
+    if (qq('body').hasClass('dark-theme')) {
+      themeToggle.html('☀️ Light Mode');
+    } else {
+      themeToggle.html('🌙 Dark Mode');
+    }
+  }
+  
 });

--- a/kona3engine/template/parts_header.html
+++ b/kona3engine/template/parts_header.html
@@ -24,6 +24,14 @@
 {{if $robots != ''}}<meta name="robots" content="{{$robots}}">{{endif}}
 </head>
 <body>
+<script>
+  (function() {
+    var theme = localStorage.getItem('kona3_theme');
+    if (theme === 'dark' || (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+      document.body.classList.add('dark-theme');
+    }
+  })();
+</script>
 
 <!-- #kona3_layout_header -->
 <div id="kona3_layout_header">
@@ -47,7 +55,9 @@
     <!-- 飛び出すメニュー -->
     <nav class="menuitems">
       {{ e:echo kona3getCtrlMenu('list') }}
-      <ul><li></li></ul>
+      <ul>
+        <li><a href="#" id="dark_mode_toggle">🌙 Dark Mode</a></li>
+      </ul>
       {{ e:echo kona3getWikiPage('GlobalBar', '') }}
     </nav>
   </div>

--- a/kona3engine/template/parts_header.html
+++ b/kona3engine/template/parts_header.html
@@ -26,9 +26,13 @@
 <body>
 <script>
   (function() {
-    var theme = localStorage.getItem('kona3_theme');
-    if (theme === 'dark' || (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
-      document.body.classList.add('dark-theme');
+    try {
+      var theme = localStorage.getItem('kona3_theme');
+      if (theme === 'dark' || (!theme && window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        document.body.classList.add('dark-theme');
+      }
+    } catch (e) {
+      console.warn("Storage access failed:", e);
     }
   })();
 </script>

--- a/kona3engine/tests/darkmode.test.php
+++ b/kona3engine/tests/darkmode.test.php
@@ -11,6 +11,7 @@ test_assert(__LINE__, strpos($css_content, 'body.dark-theme') !== false, "darkmo
 test_assert(__LINE__, strpos($css_content, 'background-color') !== false, "darkmode.css defines background-color styles");
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikiedit') !== false, "darkmode.css defines #wikiedit dark mode overrides");
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme textarea#edit_txt') !== false, "darkmode.css defines textarea#edit_txt dark mode overrides");
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme .kona3_login_bar') !== false, "darkmode.css defines .kona3_login_bar dark mode overrides");
 
 // 2. Check if parts_header.html contains toggle button and inline JS to restore preference
 $parts_header = dirname(__DIR__) . '/template/parts_header.html';

--- a/kona3engine/tests/darkmode.test.php
+++ b/kona3engine/tests/darkmode.test.php
@@ -1,0 +1,25 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+
+// Test dark mode implementation details
+
+// 1. Check if darkmode.css exists and defines body.dark-theme overrides
+$darkmode_css = dirname(__DIR__) . '/resource/darkmode.css';
+test_assert(__LINE__, file_exists($darkmode_css), "darkmode.css exists");
+$css_content = file_get_contents($darkmode_css);
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme') !== false, "darkmode.css defines body.dark-theme styles");
+test_assert(__LINE__, strpos($css_content, 'background-color') !== false, "darkmode.css defines background-color styles");
+
+// 2. Check if parts_header.html contains toggle button and inline JS to restore preference
+$parts_header = dirname(__DIR__) . '/template/parts_header.html';
+test_assert(__LINE__, file_exists($parts_header), "parts_header.html exists");
+$header_content = file_get_contents($parts_header);
+test_assert(__LINE__, strpos($header_content, 'id="dark_mode_toggle"') !== false, "parts_header.html contains dark_mode_toggle ID");
+test_assert(__LINE__, strpos($header_content, 'localStorage.getItem(\'kona3_theme\')') !== false, "parts_header.html contains inline JS reading theme preference");
+
+// 3. Check if drawer.js implements the toggle click handler
+$drawer_js = dirname(__DIR__) . '/resource/drawer.js';
+test_assert(__LINE__, file_exists($drawer_js), "drawer.js exists");
+$js_content = file_get_contents($drawer_js);
+test_assert(__LINE__, strpos($js_content, '#dark_mode_toggle') !== false, "drawer.js targets #dark_mode_toggle");
+test_assert(__LINE__, strpos($js_content, 'localStorage.setItem(\'kona3_theme\'') !== false, "drawer.js saves theme preference");

--- a/kona3engine/tests/darkmode.test.php
+++ b/kona3engine/tests/darkmode.test.php
@@ -9,6 +9,8 @@ test_assert(__LINE__, file_exists($darkmode_css), "darkmode.css exists");
 $css_content = file_get_contents($darkmode_css);
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme') !== false, "darkmode.css defines body.dark-theme styles");
 test_assert(__LINE__, strpos($css_content, 'background-color') !== false, "darkmode.css defines background-color styles");
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikiedit') !== false, "darkmode.css defines #wikiedit dark mode overrides");
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme textarea#edit_txt') !== false, "darkmode.css defines textarea#edit_txt dark mode overrides");
 
 // 2. Check if parts_header.html contains toggle button and inline JS to restore preference
 $parts_header = dirname(__DIR__) . '/template/parts_header.html';


### PR DESCRIPTION
This PR adds dark mode support. Users can toggle between Dark Mode and Light Mode via the hamburger menu. The selection is stored in localStorage to persist preferences across page views, and the theme is restored early on page load to prevent screen flickering. Closes #154.