### PR TITLE
Support Japanese headers and list markers in Markdown mode (Issue #149)

### DIFF
--- a/kona3engine/kona3parser_md.inc.php
+++ b/kona3engine/kona3parser_md.inc.php
@@ -72,17 +72,43 @@ function kona3markdown_parser_parse($text)
             kona3markdown_parser_skipEOL($text);
             continue;
         }
+        else if ($c == "■") {
+            kona3markdown_parser_getchar($text);
+            kona3markdown_parser_skipSpace($text);
+            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>1);
+            kona3markdown_parser_skipEOL($text);
+            continue;
+        }
+        else if ($c == "●") {
+            kona3markdown_parser_getchar($text);
+            kona3markdown_parser_skipSpace($text);
+            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>2);
+            kona3markdown_parser_skipEOL($text);
+            continue;
+        }
+        else if ($c == "▲") {
+            kona3markdown_parser_getchar($text);
+            kona3markdown_parser_skipSpace($text);
+            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>3);
+            kona3markdown_parser_skipEOL($text);
+            continue;
+        }
         // LIST <ul>
-        if ($c == '-' || $c2 == '* ') {
+        if ($c == '-' || $c2 == '* ' || $c == '・') {
             // hr
-            if (preg_match('#^(-{5,})\n#', $text, $m)) {
+            if ($c == '-' && preg_match('#^(-{5,})\n#', $text, $m)) {
                 $text = substr($text, strlen($m[0]));
                 kona3markdown_parser_skipEOL($text);
                 $tokens[] = array("cmd"=>"hr", "text"=>"", "level"=>$level);
             } else {
-                $text = mb_substr($text, 1);
+                if ($c == '・') {
+                    $level = kona3markdown_parser_count_level($text, '・');
+                } else {
+                    $text = mb_substr($text, 1);
+                    $level = 1;
+                }
                 kona3markdown_parser_skipSpace($text);
-                $tokens[] = array("cmd"=>"-", "text"=>kona3markdown_parser_token($text, $eol), "level"=>1);
+                $tokens[] = array("cmd"=>"-", "text"=>kona3markdown_parser_token($text, $eol), "level"=>$level);
             }
         }
         // LIST <ol>

--- a/kona3engine/kona3parser_md.inc.php
+++ b/kona3engine/kona3parser_md.inc.php
@@ -4,6 +4,12 @@
  */
 include_once 'kona3lib.inc.php';
 
+// Title and list marker constants for Japanese mode
+define('KONA3_MD_H1_MARK', '■');
+define('KONA3_MD_H2_MARK', '●');
+define('KONA3_MD_H3_MARK', '▲');
+define('KONA3_MD_UL_MARK', '・');
+
 /**
  * convert text to html
  */
@@ -39,6 +45,14 @@ function kona3markdown_getRawTokens()
 function kona3markdown_parser_parse($text)
 {
     global $eol;
+
+    // Japanese header levels mapping
+    $ja_headers = [
+        KONA3_MD_H1_MARK => 1,
+        KONA3_MD_H2_MARK => 2,
+        KONA3_MD_H3_MARK => 3,
+    ];
+
     // convert CRLF to LF
     $text = preg_replace('#(\r\n|\r)#',"\n", $text)."\n";
     kona3markdown_addPublic('EOL', "\n");
@@ -64,7 +78,7 @@ function kona3markdown_parser_parse($text)
         // check line head
         $c = mb_substr($text, 0, 1);
         $c2 = mb_substr($text, 0, 2);
-        // TITLE
+        // TITLE (Standard Markdown)
         if ($c == "#") {
             $level = kona3markdown_parser_count_level($text, $c);
             kona3markdown_parser_skipSpace($text);
@@ -72,37 +86,25 @@ function kona3markdown_parser_parse($text)
             kona3markdown_parser_skipEOL($text);
             continue;
         }
-        else if ($c == "■") {
+        // TITLE (Japanese Mode)
+        else if (isset($ja_headers[$c])) {
+            $level = $ja_headers[$c];
             kona3markdown_parser_getchar($text);
             kona3markdown_parser_skipSpace($text);
-            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>1);
-            kona3markdown_parser_skipEOL($text);
-            continue;
-        }
-        else if ($c == "●") {
-            kona3markdown_parser_getchar($text);
-            kona3markdown_parser_skipSpace($text);
-            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>2);
-            kona3markdown_parser_skipEOL($text);
-            continue;
-        }
-        else if ($c == "▲") {
-            kona3markdown_parser_getchar($text);
-            kona3markdown_parser_skipSpace($text);
-            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>3);
+            $tokens[] = array("cmd"=>"*", "text"=>kona3markdown_parser_token($text, $eol), "level"=>$level);
             kona3markdown_parser_skipEOL($text);
             continue;
         }
         // LIST <ul>
-        if ($c == '-' || $c2 == '* ' || $c == '・') {
+        if ($c == '-' || $c2 == '* ' || $c == KONA3_MD_UL_MARK) {
             // hr
             if ($c == '-' && preg_match('#^(-{5,})\n#', $text, $m)) {
                 $text = substr($text, strlen($m[0]));
                 kona3markdown_parser_skipEOL($text);
                 $tokens[] = array("cmd"=>"hr", "text"=>"", "level"=>$level);
             } else {
-                if ($c == '・') {
-                    $level = kona3markdown_parser_count_level($text, '・');
+                if ($c == KONA3_MD_UL_MARK) {
+                    $level = kona3markdown_parser_count_level($text, KONA3_MD_UL_MARK);
                 } else {
                     $text = mb_substr($text, 1);
                     $level = 1;

--- a/kona3engine/tests/kona3parser_md.test.php
+++ b/kona3engine/tests/kona3parser_md.test.php
@@ -4,6 +4,16 @@ require_once __DIR__ . '/test_common.inc.php';
 // Test Japanese headers and list markers in Markdown parser (kona3parser_md.inc.php)
 require_once dirname(__DIR__) . '/kona3parser_md.inc.php';
 
+// --- Constant Definition Tests ---
+test_assert(__LINE__, defined('KONA3_MD_H1_MARK'), "KONA3_MD_H1_MARK is defined");
+test_eq(__LINE__, KONA3_MD_H1_MARK, '■', "KONA3_MD_H1_MARK defaults to ■");
+test_assert(__LINE__, defined('KONA3_MD_H2_MARK'), "KONA3_MD_H2_MARK is defined");
+test_eq(__LINE__, KONA3_MD_H2_MARK, '●', "KONA3_MD_H2_MARK defaults to ●");
+test_assert(__LINE__, defined('KONA3_MD_H3_MARK'), "KONA3_MD_H3_MARK is defined");
+test_eq(__LINE__, KONA3_MD_H3_MARK, '▲', "KONA3_MD_H3_MARK defaults to ▲");
+test_assert(__LINE__, defined('KONA3_MD_UL_MARK'), "KONA3_MD_UL_MARK is defined");
+test_eq(__LINE__, KONA3_MD_UL_MARK, '・', "KONA3_MD_UL_MARK defaults to ・");
+
 // --- Header Tests ---
 $text = "■見出し1\n●見出し2\n▲見出し3";
 $tokens = kona3markdown_parser_parse($text);

--- a/kona3engine/tests/kona3parser_md.test.php
+++ b/kona3engine/tests/kona3parser_md.test.php
@@ -1,0 +1,44 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+
+// Test Japanese headers and list markers in Markdown parser (kona3parser_md.inc.php)
+require_once dirname(__DIR__) . '/kona3parser_md.inc.php';
+
+// --- Header Tests ---
+$text = "■見出し1\n●見出し2\n▲見出し3";
+$tokens = kona3markdown_parser_parse($text);
+
+test_eq(__LINE__, $tokens[0]['cmd'], '*', "Markdown Mode: ■ is parsed as header");
+test_eq(__LINE__, $tokens[0]['level'], 1, "Markdown Mode: ■ header level is 1");
+test_eq(__LINE__, $tokens[0]['text'], '見出し1', "Markdown Mode: ■ header text matches");
+
+test_eq(__LINE__, $tokens[1]['cmd'], '*', "Markdown Mode: ● is parsed as header");
+test_eq(__LINE__, $tokens[1]['level'], 2, "Markdown Mode: ● header level is 2");
+test_eq(__LINE__, $tokens[1]['text'], '見出し2', "Markdown Mode: ● header text matches");
+
+test_eq(__LINE__, $tokens[2]['cmd'], '*', "Markdown Mode: ▲ is parsed as header");
+test_eq(__LINE__, $tokens[2]['level'], 3, "Markdown Mode: ▲ header level is 3");
+test_eq(__LINE__, $tokens[2]['text'], '見出し3', "Markdown Mode: ▲ header text matches");
+
+// --- List Tests ---
+$text = "・項目1\n・・項目2\n・・・項目3";
+$tokens = kona3markdown_parser_parse($text);
+
+test_eq(__LINE__, $tokens[0]['cmd'], '-', "Markdown Mode: ・ is parsed as list");
+test_eq(__LINE__, $tokens[0]['level'], 1, "Markdown Mode: ・ list level is 1");
+test_eq(__LINE__, $tokens[0]['text'], '項目1', "Markdown Mode: ・ list text matches");
+
+test_eq(__LINE__, $tokens[1]['cmd'], '-', "Markdown Mode: ・・ is parsed as list");
+test_eq(__LINE__, $tokens[1]['level'], 2, "Markdown Mode: ・・ list level is 2");
+test_eq(__LINE__, $tokens[1]['text'], '項目2', "Markdown Mode: ・・ list text matches");
+
+test_eq(__LINE__, $tokens[2]['cmd'], '-', "Markdown Mode: ・・・ is parsed as list");
+test_eq(__LINE__, $tokens[2]['level'], 3, "Markdown Mode: ・・・ list level is 3");
+test_eq(__LINE__, $tokens[2]['text'], '項目3', "Markdown Mode: ・・・ list text matches");
+
+// --- HTML Rendering Tests ---
+$text = "■テスト見出し\n・テストリスト";
+$html = kona3markdown_parser_convert($text);
+
+test_assert(__LINE__, strpos($html, '<h1') !== false, "Markdown Mode: ■ translates to <h1> tag");
+test_assert(__LINE__, strpos($html, '<li>テストリスト') !== false, "Markdown Mode: ・ translates to <li> tag");


### PR DESCRIPTION
This PR adds support for Japanese headers (■, ●, ▲) and list markers (・) in Markdown mode to align with the standard Konawiki parser's behavior. Closes #149.