### PR TITLE
[codex] Improve admin config UI

### DIFF
--- a/kona3engine/action/admin.inc.php
+++ b/kona3engine/action/admin.inc.php
@@ -60,6 +60,7 @@ function kona3setup_config()
         if (isset($_GET['admin'])) {
             $conf['admin_email'] = $_GET['admin'];
         }
+        $conf['config_items'] = kona3conf_getConfigFormItems($conf);
         kona3template('admin_conf.html', $conf);
         exit;
     }
@@ -90,18 +91,11 @@ function kona3setup_config()
         unset($_POST['admin_pw1']); // unset admin_pw1 and admin_pw2
         unset($_POST['admin_pw2']);
         // save
-        foreach ($conf as $key => $def) {
-            $v = isset($_POST[$key]) ? $_POST[$key] : $def;
-            if (is_string($v)) {
-                $v = trim($v);
-                if (strtolower($v) === 'true') {
-                    $v = TRUE;
-                }
-                if (strtolower($v) === 'false') {
-                    $v = FALSE;
-                }
+        $configItems = kona3conf_getFlatConfigItems();
+        foreach ($configItems as $key => $item) {
+            if (array_key_exists($key, $_POST)) {
+                $conf[$key] = kona3conf_normalizeConfigValue($_POST[$key], $item);
             }
-            $conf[$key] = $v;
         }
         // check parameters
         if (!isset($conf['FrontPage'])) {
@@ -122,6 +116,8 @@ function kona3setup_config()
             exit;
         }
         // save
+        unset($conf['plugin.disallow']);
+        unset($conf['config_items']);
         jsonphp_save($file_conf, $conf);
         kona3setup_showMessage('<h1>Saved</h1><p><a href="./index.php">Go to FrontPage.</a></p>');
         exit;

--- a/kona3engine/kona3conf.inc.php
+++ b/kona3engine/kona3conf.inc.php
@@ -41,52 +41,15 @@ function kona3conf_setPHPConf()
 function kona3conf_setWikiConf(&$kona3conf)
 {
     // default settings
-    $defaultConf = [
+    $defaultConf = kona3conf_getDefaultValues();
+    $systemDefaultConf = [
         'KONAWIKI_VERSION' => KONAWIKI_VERSION,
-        'wiki_title' => 'KonaWiki3',
-        'session_name' => 'kona3session',
-        'admin_email' => 'admin@example.com',
-        'wiki_private' => TRUE,
-        'lang' => 'ja',
-        'skin' => 'def',
-        'def_text_ext' => 'txt',
-        'allow_add_user' => FALSE,
-        'allpage_header' => '',
-        'allpage_footer' => '',
-        'analytics' => '',
-        'FrontPage' => 'FrontPage',
-        'plugin_disallow' => 'html,htmlshow,filelist',
-        'git_enabled' => FALSE,
-        'git_branch' => 'main',
-        'git_remote_repository' => 'origin',
-        'noanchor' => FALSE,
-        'enc_pagename' => FALSE,
-        'show_data_dir' => FALSE,
-        'show_counter' => FALSE,
-        'para_enabled_br' => TRUE,
-        'path_max_mkdir' => 3,
-        'chmod_mkdir' => '0777',
-        'max_edit_size' => '3',
-        'max_search' => '10',
-        'max_search_level' => '2',
-        'use_pdf_out' => FALSE,
-        'image_pattern' => '(png|jpg|jpeg|gif|bmp|ico|svg|webp)',
-        # data_dir_allow_pattern (※テキストデータを直接ダウンロードさせないように限定したデータのみ許可)
-        'data_dir_allow_pattern' => '(csv|json|xml|doc|docx|xls|xlsx|ppt|pptx|pdf|zip|gz|bz2|wav|mid|mp3|mp4|ogg|mmd|mermaid|yaml|yml)',
-        'allow_upload' => FALSE,
-        'allow_upload_ext' => 'txt;md;pdf;csv;wav;mid;mp3;mp4;ogg;zip;gz;bz2;jpg;jpeg;png;gif;webp;svg;xml;json;ini;doc;docx;xls;xlsx;ppt;pptx',
-        'upload_max_file_size' => 1024 * 1024 * 5,
-        'bbs_admin_password' => 'BBS#admin!PassWord!!',
-        'openai_apikey' => '',
-        'openai_apikey_model' => 'gpt-4o-mini',
-        'openai_api_basic_instruction' => 'You are helpful AI assitant.',
-        'discord_webhook_url' => '',
         'plugin_alias' => [
             "画像" => "ref",
             "なでしこ" => "nako3",
         ],
-        'mermaid_cli' => '',
     ];
+    $defaultConf = array_merge($defaultConf, $systemDefaultConf);
     kona3conf_setDefault($kona3conf, $defaultConf);
 
     // -------------------------------------------
@@ -98,6 +61,197 @@ function kona3conf_setWikiConf(&$kona3conf)
         $plugin_disallow_kv[$name] = TRUE;
     }
     $kona3conf["plugin.disallow"] = $plugin_disallow_kv;
+}
+
+function kona3conf_getConfigItems()
+{
+    return [
+        'Basic' => [
+            'wiki_title' => ['label' => 'Wiki Title', 'default' => 'KonaWiki3', 'type' => 'string'],
+            'session_name' => ['label' => 'Session Name', 'default' => 'kona3session', 'type' => 'string'],
+            'admin_email' => ['label' => 'Admin Email', 'default' => 'admin@example.com', 'type' => 'string'],
+            'wiki_private' => ['label' => 'Wiki Private', 'default' => TRUE, 'type' => 'bool'],
+            'lang' => ['label' => 'Language', 'default' => 'ja', 'type' => 'select', 'items' => ['ja', 'en']],
+            'skin' => ['label' => 'Skin name', 'default' => 'def', 'type' => 'select', 'items' => kona3conf_getSkinItems()],
+            'allow_add_user' => ['label' => 'Allow Add User', 'default' => FALSE, 'type' => 'bool'],
+            'def_text_ext' => ['label' => 'Default Text Ext', 'default' => 'txt', 'type' => 'select', 'items' => ['txt', 'md']],
+            'bbs_admin_password' => ['label' => 'BBS Admin Password', 'default' => 'BBS#admin!PassWord!!', 'type' => 'string'],
+        ],
+        'Header/Footer' => [
+            'allpage_header' => ['label' => 'All Page Header', 'default' => '', 'type' => 'string', 'note' => 'wiki text'],
+            'allpage_footer' => ['label' => 'All Page Footer', 'default' => '', 'type' => 'string', 'note' => 'wiki text'],
+            'analytics' => ['label' => 'Analytics Code', 'default' => '', 'type' => 'string', 'note' => 'html'],
+        ],
+        'Options' => [
+            'FrontPage' => ['label' => 'FrontPage Name', 'default' => 'FrontPage', 'type' => 'string'],
+            'plugin_disallow' => ['label' => 'Disabled Plugins', 'default' => 'html,htmlshow,filelist', 'type' => 'string', 'note' => "delimiter=','"],
+            'show_counter' => ['label' => 'Show Counter', 'default' => FALSE, 'type' => 'bool'],
+            'show_data_dir' => ['label' => 'Show Data Directory', 'default' => FALSE, 'type' => 'bool'],
+            'data_dir_allow_pattern' => [
+                'label' => 'Data Directory Allow Pattern',
+                'default' => '(csv|json|xml|doc|docx|xls|xlsx|ppt|pptx|pdf|zip|gz|bz2|wav|mid|mp3|mp4|ogg|mmd|mermaid|yaml|yml)',
+                'type' => 'string',
+                'note' => 'Specify a pattern excluding images',
+            ],
+            'noanchor' => ['label' => 'No Anchor', 'default' => FALSE, 'type' => 'bool'],
+            'enc_pagename' => ['label' => 'Encode Page Name', 'default' => FALSE, 'type' => 'bool'],
+            'use_pdf_out' => ['label' => 'Use PDF Output', 'default' => FALSE, 'type' => 'bool'],
+            'para_enabled_br' => ['label' => 'Paragraph BR', 'default' => TRUE, 'type' => 'bool'],
+            'path_max_mkdir' => ['label' => 'Path Max Mkdir', 'default' => 3, 'type' => 'number', 'note' => '0:off, 1,2,3...:on'],
+            'chmod_mkdir' => ['label' => 'Chmod Mkdir', 'default' => '0777', 'type' => 'string'],
+            'max_edit_size' => ['label' => 'Max Edit Size', 'default' => 3, 'type' => 'number', 'note' => '0:no limit, unit=MB'],
+            'max_search' => ['label' => 'Max Search', 'default' => 10, 'type' => 'number'],
+            'max_search_level' => ['label' => 'Max Search Level', 'default' => 2, 'type' => 'number'],
+        ],
+        'Uploader' => [
+            'image_pattern' => ['label' => 'Image Pattern', 'default' => '(png|jpg|jpeg|gif|bmp|ico|svg|webp)', 'type' => 'string'],
+            'allow_upload' => ['label' => 'Allow Upload', 'default' => FALSE, 'type' => 'bool'],
+            'allow_upload_ext' => [
+                'label' => 'Allow Upload Ext',
+                'default' => 'txt;md;pdf;csv;wav;mid;mp3;mp4;ogg;zip;gz;bz2;jpg;jpeg;png;gif;webp;svg;xml;json;ini;doc;docx;xls;xlsx;ppt;pptx',
+                'type' => 'string',
+            ],
+            'upload_max_file_size' => ['label' => 'Upload Max File Size', 'default' => 1024 * 1024 * 5, 'type' => 'number', 'note' => 'bytes'],
+        ],
+        'AI' => [
+            'openai_apikey' => ['label' => 'OpenAI API Key', 'default' => '', 'type' => 'string', 'note' => 'for ChatGPT'],
+            'openai_apikey_model' => ['label' => 'OpenAI API Model', 'default' => 'gpt-4o-mini', 'type' => 'select', 'items' => ['gpt-4o-mini', 'gpt-4o']],
+            'openai_api_basic_instruction' => ['label' => 'OpenAI Basic Instruction', 'default' => 'You are helpful AI assitant.', 'type' => 'string'],
+            'mermaid_cli' => ['label' => 'Mermaid CLI', 'default' => '', 'type' => 'string'],
+        ],
+        'Discord' => [
+            'discord_webhook_url' => ['label' => 'Discord Webhook URL', 'default' => '', 'type' => 'string'],
+        ],
+        'Git' => [
+            'git_enabled' => ['label' => 'Git Enabled', 'default' => FALSE, 'type' => 'bool'],
+            'git_branch' => ['label' => 'Git Branch', 'default' => 'main', 'type' => 'string'],
+            'git_remote_repository' => ['label' => 'Git Remote Repository', 'default' => 'origin', 'type' => 'string'],
+        ],
+    ];
+}
+
+function kona3conf_getDefaultValues()
+{
+    $defaults = [];
+    foreach (kona3conf_getConfigItems() as $items) {
+        foreach ($items as $key => $item) {
+            $defaults[$key] = $item['default'];
+        }
+    }
+    return $defaults;
+}
+
+function kona3conf_getFlatConfigItems()
+{
+    $flatItems = [];
+    foreach (kona3conf_getConfigItems() as $items) {
+        foreach ($items as $key => $item) {
+            $flatItems[$key] = $item;
+        }
+    }
+    return $flatItems;
+}
+
+function kona3conf_getConfigFormItems($conf)
+{
+    $categories = kona3conf_getConfigItems();
+    foreach ($categories as &$items) {
+        foreach ($items as $key => &$item) {
+            $item['name'] = $key;
+            if (!isset($item['note'])) {
+                $item['note'] = '';
+            }
+            $value = array_key_exists($key, $conf) ? $conf[$key] : $item['default'];
+            $item['input_html'] = kona3conf_renderConfigInput($key, $item, $value);
+        }
+    }
+    return $categories;
+}
+
+function kona3conf_renderConfigInput($key, $item, $value)
+{
+    $type = isset($item['type']) ? $item['type'] : 'string';
+    $id = 'conf_' . preg_replace('/[^a-zA-Z0-9_\-]/', '_', $key);
+    $name = htmlspecialchars($key, ENT_QUOTES, 'UTF-8');
+    $idEsc = htmlspecialchars($id, ENT_QUOTES, 'UTF-8');
+    if ($type === 'bool') {
+        $selectedTrue = $value ? ' selected' : '';
+        $selectedFalse = $value ? '' : ' selected';
+        return "<select id=\"{$idEsc}\" name=\"{$name}\">" .
+            "<option value=\"true\"{$selectedTrue}>true</option>" .
+            "<option value=\"false\"{$selectedFalse}>false</option>" .
+            "</select>";
+    }
+    if ($type === 'select') {
+        $items = isset($item['items']) ? $item['items'] : [];
+        $valueStr = (string)$value;
+        if (!in_array($valueStr, $items, TRUE)) {
+            $items[] = $valueStr;
+        }
+        $html = "<select id=\"{$idEsc}\" name=\"{$name}\">";
+        foreach ($items as $option) {
+            $optionStr = (string)$option;
+            $optionEsc = htmlspecialchars($optionStr, ENT_QUOTES, 'UTF-8');
+            $selected = ($optionStr === $valueStr) ? ' selected' : '';
+            $html .= "<option value=\"{$optionEsc}\"{$selected}>{$optionEsc}</option>";
+        }
+        $html .= '</select>';
+        return $html;
+    }
+    $inputType = ($type === 'number') ? 'number' : 'text';
+    $valueEsc = htmlspecialchars((string)$value, ENT_QUOTES, 'UTF-8');
+    return "<input type=\"{$inputType}\" id=\"{$idEsc}\" name=\"{$name}\" value=\"{$valueEsc}\">";
+}
+
+function kona3conf_normalizeConfigValue($value, $item)
+{
+    $type = isset($item['type']) ? $item['type'] : 'string';
+    if (is_string($value)) {
+        $value = trim($value);
+    }
+    if ($type === 'bool') {
+        if (is_bool($value)) {
+            return $value;
+        }
+        $valueLower = strtolower((string)$value);
+        return in_array($valueLower, ['1', 'true', 'on', 'yes'], TRUE);
+    }
+    if ($type === 'number') {
+        if ($value === '') {
+            return $item['default'];
+        }
+        if (is_numeric($value)) {
+            return (strpos((string)$value, '.') !== FALSE) ? (float)$value : (int)$value;
+        }
+        return $item['default'];
+    }
+    if ($type === 'select') {
+        $valueStr = (string)$value;
+        $items = isset($item['items']) ? $item['items'] : [];
+        return in_array($valueStr, $items, TRUE) ? $valueStr : $item['default'];
+    }
+    return $value;
+}
+
+function kona3conf_getSkinItems()
+{
+    $skins = ['def'];
+    if (defined('KONA3_DIR_SKIN') && is_dir(KONA3_DIR_SKIN)) {
+        $dirs = scandir(KONA3_DIR_SKIN);
+        foreach ($dirs as $dir) {
+            if ($dir === '.' || $dir === '..') {
+                continue;
+            }
+            if (is_dir(KONA3_DIR_SKIN . '/' . $dir) && preg_match('/^[a-zA-Z0-9_\-]+$/', $dir)) {
+                $skins[] = $dir;
+            }
+        }
+    } else {
+        $skins = array_merge($skins, ['single', 'nako3']);
+    }
+    $skins = array_values(array_unique($skins));
+    sort($skins);
+    return $skins;
 }
 
 function check_conf(&$conf, $key, $def)

--- a/kona3engine/kona3conf.inc.php
+++ b/kona3engine/kona3conf.inc.php
@@ -116,7 +116,7 @@ function kona3conf_getConfigItems()
         'AI' => [
             'openai_apikey' => ['label' => 'OpenAI API Key', 'default' => '', 'type' => 'string', 'note' => 'for ChatGPT'],
             'openai_apikey_model' => ['label' => 'OpenAI API Model', 'default' => 'gpt-4o-mini', 'type' => 'select', 'items' => ['gpt-4o-mini', 'gpt-4o']],
-            'openai_api_basic_instruction' => ['label' => 'OpenAI Basic Instruction', 'default' => 'You are helpful AI assitant.', 'type' => 'string'],
+            'openai_api_basic_instruction' => ['label' => 'OpenAI Basic Instruction', 'default' => 'You are helpful AI assistant.', 'type' => 'string'],
             'mermaid_cli' => ['label' => 'Mermaid CLI', 'default' => '', 'type' => 'string'],
         ],
         'Discord' => [
@@ -162,6 +162,7 @@ function kona3conf_getConfigFormItems($conf)
                 $item['note'] = '';
             }
             $value = array_key_exists($key, $conf) ? $conf[$key] : $item['default'];
+            $value = kona3conf_normalizeConfigValue($value, $item);
             $item['input_html'] = kona3conf_renderConfigInput($key, $item, $value);
         }
     }
@@ -221,7 +222,8 @@ function kona3conf_normalizeConfigValue($value, $item)
             return $item['default'];
         }
         if (is_numeric($value)) {
-            return (strpos((string)$value, '.') !== FALSE) ? (float)$value : (int)$value;
+            $number = (float)$value;
+            return floor($number) == $number ? (int)$number : $number;
         }
         return $item['default'];
     }
@@ -235,6 +237,10 @@ function kona3conf_normalizeConfigValue($value, $item)
 
 function kona3conf_getSkinItems()
 {
+    static $skinItems = NULL;
+    if ($skinItems !== NULL) {
+        return $skinItems;
+    }
     $skins = ['def'];
     if (defined('KONA3_DIR_SKIN') && is_dir(KONA3_DIR_SKIN)) {
         $dirs = scandir(KONA3_DIR_SKIN);
@@ -251,7 +257,8 @@ function kona3conf_getSkinItems()
     }
     $skins = array_values(array_unique($skins));
     sort($skins);
-    return $skins;
+    $skinItems = $skins;
+    return $skinItems;
 }
 
 function check_conf(&$conf, $key, $def)

--- a/kona3engine/template/admin_conf.html
+++ b/kona3engine/template/admin_conf.html
@@ -27,10 +27,26 @@
       border-bottom: 1px dotted silver;
       background-color: #f0f0ff;
     }
-    #wikimessage input[type='text'], #wikimessage input[type='password'] {
+    #wikimessage input[type='text'],
+    #wikimessage input[type='number'],
+    #wikimessage input[type='password'],
+    #wikimessage select {
       font-size: 1em;
       padding: 0.5em;
       width: 20em;
+    }
+    #wikimessage .conf-item {
+      margin: 0.6em 0;
+    }
+    #wikimessage .conf-item label {
+      display: block;
+      font-weight: bold;
+      margin-bottom: 0.25em;
+    }
+    #wikimessage .conf-note {
+      color: #555;
+      font-size: 0.9em;
+      margin-left: 0.4em;
     }
 </style>
 
@@ -44,91 +60,20 @@
         {{ 'Please review the settings.' | lang }}<br>
         <input type='button' value='Save' onclick='document.forms[0].submit();'>
       </div>
-      <h3>Basic</h3>
-      Wiki Title:<br>
-      <input type='text' name='wiki_title' value='{{$wiki_title}}'><br>
-      Admin Email:<br>
-      <input type='text' name='admin_email' value='{{$admin_email}}'><br>
-      Wiki Private(true/false):<br>
-      <input type='text' name='wiki_private' value='{{$wiki_private | boolstr}}'><br>
-      Language (ja/en):<br>
-      <input type='text' name='lang' value='{{$lang}}'><br>
-      Skin name (def|single|nako3):<br>
-      <input type='text' name='skin' value='{{$skin}}'><br>
-      allow_add_user (true|false):<br>
-      <input type='text' name='allow_add_user' value='{{$allow_add_user | boolstr}}'><br>
-      Default text ext (txt/md):<br>
-      <input type='text' name='def_text_ext' value='{{$def_text_ext}}'><br>
-      bbs_admin_password:<br>
-      <input type='text' name='bbs_admin_password' value='{{$bbs_admin_password}}'><br>
-
-      <h3>Header/Footer</h3>
-      allpage_header (wiki text):<br>
-      <input type='text' name='allpage_header' value='{{$allpage_header}}'><br>  
-      allpage_footer (wiki text):<br>
-      <input type='text' name='allpage_footer' value='{{$allpage_footer}}'><br>
-      analytics code (html):<br>
-      <input type='text' name='analytics' value='{{$analytics}}'><br>
-      
-      <h3>Options</h3>
-      FrontPage Name:<br>
-      <input type='text' name='FrontPage' value='{{$FrontPage}}'><br>
-      plugin_disallow (delimiter=','):<br>
-      <input type='text' name='plugin_disallow' value='{{$plugin_disallow}}'><br>
-      show_counter (true/false):<br>
-      <input type='text' name='show_counter' value='{{$show_counter | boolstr}}'><br>
-      show_data_dir (true/false):<br>
-      <input type='text' name='show_data_dir' value='{{$show_data_dir | boolstr}}'><br>
-      data_dir_allow_pattern [Specify a pattern excluding images]:<br>
-      <input type='text' name='data_dir_allow_pattern' value='{{$data_dir_allow_pattern}}'><br>
-      noanchor (true/false):<br>
-      <input type='text' name='noanchor' value='{{$noanchor | boolstr}}'><br>
-      enc_pagename(true/false):<br>
-      <input type='text' name='enc_pagename' value='{{$enc_pagename | boolstr}}'><br>
-      use_pdf_out(true/false):<br>
-      <input type='text' name='use_pdf_out' value='{{$use_pdf_out | boolstr}}'><br>
-      para_enabled_br(true/false):<br>
-      <input type='text' name='para_enabled_br' value='{{$para_enabled_br | boolstr}}'><br>
-      path_max_mkdir(0:off, 1,2,3...:on):<br>
-      <input type='text' name='path_max_mkdir' value='{{$path_max_mkdir}}'><br>
-      chmod_mkdir(default:0777):<br>
-      <input type='text' name='chmod_mkdir' value='{{$chmod_mkdir}}'><br>
-      max_edit_size(0:no limit, unit=MB):<br>
-      <input type='text' name='max_edit_size' value='{{$max_edit_size}}'><br>
-      max_search:<br>
-      <input type='text' name='max_search' value='{{$max_search}}'><br>
-      max_search_level:<br>
-      <input type='text' name='max_search_level' value='{{$max_search_level}}'><br>
-
-      <h3>Uploader</h3>
-      allow_upload(true/false):<br>
-      <input type='text' name='allow_upload' value='{{$allow_upload | boolstr}}'><br>
-      allow_upload_ext:<br>
-      <input type='text' name='allow_upload_ext' value='{{$allow_upload_ext}}'><br>
-      upload_max_file_size(bytes):<br>
-      <input type='text' name='upload_max_file_size' value='{{$upload_max_file_size}}'><br>
-
-      <!-- ai -->
-      <h3>AI</h3>
-      openai_apikey(for CharGPT)[<a href="https://kujirahand.com/konawiki3/index.php?AI" target="_new">help</a>]:<br>
-      <input type='text' name='openai_apikey' value='{{$openai_apikey}}'><br>
-      openai_apikey_model (ex) ( gpt-4o-mini | gpt-4o ):<br>
-      <input type='text' name='openai_apikey_model' value='{{$openai_apikey_model}}'><br>
-      openai_api_basic_instruction:<br>
-      <input type='text' name='openai_api_basic_instruction' value='{{$openai_api_basic_instruction}}'><br>
-      <!-- /ai -->
-
-      <h3>Discord</h3>
-      Discord webhook URL:<br>
-      <input type='text' name='discord_webhook_url' value='{{$discord_webhook_url}}'><br>
-
-      <h3>Git</h3>
-      git_enabled(true/false):<br>
-      <input type='text' name='git_enabled' value='{{$git_enabled | boolstr}}'><br>
-      git_branch:<br>
-      <input type='text' name='git_branch' value='{{$git_branch}}'><br>
-      git_remote_repository:<br>
-      <input type='text' name='git_remote_repository' value='{{$git_remote_repository}}'><br>
+      {{ for $config_items as $category => $items }}
+      <h3>{{$category}}</h3>
+        {{ for $items as $item }}
+        <div class="conf-item">
+          <label for="conf_{{$item.name}}">
+            {{$item.label}}
+            {{ if $item.note }}
+            <span class="conf-note">({{$item.note}})</span>
+            {{ endif }}
+          </label>
+          {{$item.input_html | safe}}
+        </div>
+        {{ endfor }}
+      {{ endfor }}
 
       <h3>{{'Admin password'|lang}}</h3>
       <div style="border: 1px solid silver; padding: 0.6em;">

--- a/kona3engine/tests/kona3conf.test.php
+++ b/kona3engine/tests/kona3conf.test.php
@@ -201,17 +201,21 @@ test_assert(__LINE__, isset($flat_items['allow_upload']), "設定項目定義: �
 test_eq(__LINE__, kona3conf_normalizeConfigValue('false', $flat_items['wiki_private']), FALSE, "設定値正規化: bool false");
 test_eq(__LINE__, kona3conf_normalizeConfigValue('true', $flat_items['wiki_private']), TRUE, "設定値正規化: bool true");
 test_eq(__LINE__, kona3conf_normalizeConfigValue('12', $flat_items['max_search']), 12, "設定値正規化: number int");
+test_eq(__LINE__, kona3conf_normalizeConfigValue('1e3', $flat_items['max_search']), 1000, "設定値正規化: number scientific notation");
 test_eq(__LINE__, kona3conf_normalizeConfigValue('md', $flat_items['def_text_ext']), 'md', "設定値正規化: select valid");
 test_eq(__LINE__, kona3conf_normalizeConfigValue('html', $flat_items['def_text_ext']), 'txt', "設定値正規化: select invalidはdefault");
+test_eq(__LINE__, $flat_items['openai_api_basic_instruction']['default'], 'You are helpful AI assistant.', "設定項目定義: OpenAI初期文言");
 
 $form_items = kona3conf_getConfigFormItems([
-    'wiki_private' => FALSE,
+    'wiki_private' => 'false',
     'lang' => 'en',
     'max_search' => 25,
+    'def_text_ext' => 'html',
 ]);
 test_assert(__LINE__, strpos($form_items['Basic']['wiki_private']['input_html'], '<select') !== FALSE, "設定フォーム: boolはselect");
 test_assert(__LINE__, strpos($form_items['Basic']['wiki_private']['input_html'], 'value="false" selected') !== FALSE, "設定フォーム: boolの選択状態");
 test_assert(__LINE__, strpos($form_items['Basic']['lang']['input_html'], 'value="en" selected') !== FALSE, "設定フォーム: selectの選択状態");
+test_assert(__LINE__, strpos($form_items['Basic']['def_text_ext']['input_html'], 'value="txt" selected') !== FALSE, "設定フォーム: invalid selectはdefault表示");
 test_assert(__LINE__, strpos($form_items['Options']['max_search']['input_html'], 'type="number"') !== FALSE, "設定フォーム: number入力");
 
 // --- 定数のテスト ---

--- a/kona3engine/tests/kona3conf.test.php
+++ b/kona3engine/tests/kona3conf.test.php
@@ -184,6 +184,36 @@ test_eq(__LINE__, isset($kona3conf['wiki_title']), true, "デフォルト設定:
 test_eq(__LINE__, isset($kona3conf['lang']), true, "デフォルト設定: langが設定されている");
 test_eq(__LINE__, isset($kona3conf['skin']), true, "デフォルト設定: skinが設定されている");
 
+// --- 管理画面の設定項目定義 ---
+
+$config_items = kona3conf_getConfigItems();
+test_assert(__LINE__, isset($config_items['Basic']['wiki_private']), "設定項目定義: wiki_privateが定義されている");
+test_eq(__LINE__, $config_items['Basic']['wiki_private']['type'], 'bool', "設定項目定義: wiki_privateはbool");
+test_eq(__LINE__, $config_items['Basic']['lang']['type'], 'select', "設定項目定義: langはselect");
+test_eq(__LINE__, $config_items['Options']['max_search']['type'], 'number', "設定項目定義: max_searchはnumber");
+
+$default_values = kona3conf_getDefaultValues();
+test_eq(__LINE__, $default_values['wiki_title'], 'KonaWiki3', "設定項目定義: デフォルト値が作成される");
+test_eq(__LINE__, $default_values['def_text_ext'], 'txt', "設定項目定義: selectのデフォルト値が作成される");
+
+$flat_items = kona3conf_getFlatConfigItems();
+test_assert(__LINE__, isset($flat_items['allow_upload']), "設定項目定義: フラットな項目一覧が取得できる");
+test_eq(__LINE__, kona3conf_normalizeConfigValue('false', $flat_items['wiki_private']), FALSE, "設定値正規化: bool false");
+test_eq(__LINE__, kona3conf_normalizeConfigValue('true', $flat_items['wiki_private']), TRUE, "設定値正規化: bool true");
+test_eq(__LINE__, kona3conf_normalizeConfigValue('12', $flat_items['max_search']), 12, "設定値正規化: number int");
+test_eq(__LINE__, kona3conf_normalizeConfigValue('md', $flat_items['def_text_ext']), 'md', "設定値正規化: select valid");
+test_eq(__LINE__, kona3conf_normalizeConfigValue('html', $flat_items['def_text_ext']), 'txt', "設定値正規化: select invalidはdefault");
+
+$form_items = kona3conf_getConfigFormItems([
+    'wiki_private' => FALSE,
+    'lang' => 'en',
+    'max_search' => 25,
+]);
+test_assert(__LINE__, strpos($form_items['Basic']['wiki_private']['input_html'], '<select') !== FALSE, "設定フォーム: boolはselect");
+test_assert(__LINE__, strpos($form_items['Basic']['wiki_private']['input_html'], 'value="false" selected') !== FALSE, "設定フォーム: boolの選択状態");
+test_assert(__LINE__, strpos($form_items['Basic']['lang']['input_html'], 'value="en" selected') !== FALSE, "設定フォーム: selectの選択状態");
+test_assert(__LINE__, strpos($form_items['Options']['max_search']['input_html'], 'type="number"') !== FALSE, "設定フォーム: number入力");
+
 // --- 定数のテスト ---
 
 test_eq(__LINE__, defined('KONA3_DIR_DATA'), true, "定数: KONA3_DIR_DATAが定義されている");


### PR DESCRIPTION
## Summary
- Add a config item definition list with labels, defaults, types, and selectable items
- Generate the admin config form dynamically from that definition
- Normalize saved bool/select/number values based on the item type
- Add regression coverage for config item definitions, value normalization, and generated form inputs

## Why
Issue #164 requested replacing the all-text admin config inputs with type-aware UI controls such as select boxes for booleans, language, skin, and default text extension.

## Validation
- `php -l kona3engine/kona3conf.inc.php`
- `php -l kona3engine/action/admin.inc.php`
- `php kona3engine/tests/kona3conf.test.php`
- `just test` -> `561/561 Success`

`just test` still prints existing warnings from other tests, but exits successfully.