### PR TITLE
[codex] Fix admin config dark mode headings

### DIFF
--- a/kona3engine/resource/darkmode.css
+++ b/kona3engine/resource/darkmode.css
@@ -114,6 +114,21 @@ body.dark-theme #wikimessage .box_border {
   border: 1px solid #444 !important;
 }
 
+body.dark-theme #wikimessage h2 {
+  background-color: #1e1e3f !important;
+  border-top: 1px solid #555 !important;
+  border-bottom: 1px solid #444 !important;
+  border-left-color: #555 !important;
+  color: #d0d0ff !important;
+}
+
+body.dark-theme #wikimessage h3 {
+  background-color: #1e1e3f !important;
+  border-top: 1px solid #444 !important;
+  border-bottom: 1px dotted #555 !important;
+  color: #c0c0ff !important;
+}
+
 /* drawer/hamburger list menu in dark mode */
 body.dark-theme #drawer_wrapper nav.menuitems ul li {
   background-color: #222 !important;
@@ -275,5 +290,4 @@ body.dark-theme .kona3_login_bar {
 body.dark-theme .kona3_login_bar a {
   color: #3793ef !important;
 }
-
 

--- a/kona3engine/tests/darkmode.test.php
+++ b/kona3engine/tests/darkmode.test.php
@@ -12,6 +12,8 @@ test_assert(__LINE__, strpos($css_content, 'background-color') !== false, "darkm
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikiedit') !== false, "darkmode.css defines #wikiedit dark mode overrides");
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme textarea#edit_txt') !== false, "darkmode.css defines textarea#edit_txt dark mode overrides");
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme .kona3_login_bar') !== false, "darkmode.css defines .kona3_login_bar dark mode overrides");
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikimessage h2') !== false, "darkmode.css defines #wikimessage h2 dark mode overrides");
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikimessage h3') !== false, "darkmode.css defines #wikimessage h3 dark mode overrides");
 
 // 2. Check if parts_header.html contains toggle button and inline JS to restore preference
 $parts_header = dirname(__DIR__) . '/template/parts_header.html';


### PR DESCRIPTION
## Summary
- Add dark-mode overrides for `#wikimessage h2` and `#wikimessage h3`
- Keep the admin config page headings from using the light inline background in dark mode
- Add dark mode regression checks for the `#wikimessage` heading overrides

## Why
Issue #166 reported that the admin config screen dark mode was incomplete because the `h2` heading background stayed light.

## Validation
- `php kona3engine/tests/darkmode.test.php`
- `git diff --check`
- `just test` -> `566/566 Success`

`just test` still prints existing warnings from other tests, but exits successfully.