### PR TITLE
[codex] Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  php-tests:
+    name: PHP tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.3'
+          coverage: none
+
+      - name: Run tests
+        run: php kona3engine/tests/test_main.php go_test

--- a/kona3engine/tests/test_main.php
+++ b/kona3engine/tests/test_main.php
@@ -41,6 +41,8 @@ if ($KONA3_TEST_NG > 0) {
     foreach ($KONA3_TEST_ERRORS as $err) {
         print_r($err);
     }
+    exit(1);
 } else {
     echo "| 😊 Success!\n";
+    exit(0);
 }


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that runs the PHP test suite on push and pull_request.
- Make the test runner return a non-zero exit code when any test assertion fails, so CI can detect failures correctly.

## Why
The test runner previously printed failures but still exited successfully. That meant GitHub Actions could show a green check even when the suite reported failed tests.

## Validation
- `php kona3engine/tests/test_main.php go_test`
- `just test`
- Verified with a temporary failing test that `just test` exits with code 1 after the runner change.