### PR TITLE
新規ページ作成時に kona3db_getPageId が 0 を返すバグを修正

### DIFF
--- a/kona3engine/kona3db.inc.php
+++ b/kona3engine/kona3db.inc.php
@@ -35,6 +35,7 @@ function kona3db_getPageId($page, $canCreate = FALSE)
         }
         $kona3pageIds[$page] = $maxId + 1;
         kona3lock_save(KONA3_PAGE_ID_JSON, json_encode($kona3pageIds, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+        return $kona3pageIds[$page];
     }
     return 0;
 }


### PR DESCRIPTION
## 概要
新規にページIDを作成する際、`kona3db_getPageId` 関数が新しく割り当てられた ID ではなく `0` を返してしまう不具合を修正しました。

## 原因
`kona3db_getPageId` の `$canCreate = TRUE` のブロック内で、新しい ID（`$maxId + 1`）を割り当てて保存しているものの、関数内で `return` しておらず、そのままフォールスルーして最下部の `return 0;` に到達していました。
この結果、メタ情報ファイルの保存処理（`kona3db_savePageMeta`）などで新規作成時に `page_id === 0` と判定され、保存処理が失敗（`FALSE`）していました。

## 修正内容
`if ($canCreate)` ブロックの末尾に `return $kona3pageIds[$page];` を追加し、新規作成されたページIDを正しく返すように修正しました。