### PR TITLE
[codex] ページIDを廃止してaliasリダイレクトを追加

### DIFF
--- a/kona3engine/action/go.inc.php
+++ b/kona3engine/action/go.inc.php
@@ -4,16 +4,17 @@
 function kona3_action_go()
 {
     global $kona3conf;
-    $page_id = intval($kona3conf["page"]);
-    $page = kona3db_getPageNameById($page_id);
-    if ($page == '') {
-        header("HTTP/1.1 404 Not Found");
-        echo "<h3>Page Not found ...</h3>";
-        echo "<p><a href=\"index.php\">The page(page_id=$page_id) is not found...</a></p>";
-        exit;
-    }
-    $url = kona3getPageURL($page, 'show');
+    $url = kona3go_getRedirectURL($kona3conf['page']);
     header("location: $url");
     echo "<a href='$url'>JUMP</a>";
     exit;
+}
+
+function kona3go_getRedirectURL($page)
+{
+    $page = trim($page);
+    if ($page === '') {
+        return 'index.php';
+    }
+    return 'index.php?' . urlencode($page) . '&show';
 }

--- a/kona3engine/action/show.inc.php
+++ b/kona3engine/action/show.inc.php
@@ -25,6 +25,7 @@ function kona3_action_show($actionMode = "")
         } else {
             $kona3conf['data_filename'] = $fname;
             $file_exists = TRUE;
+            kona3show_redirect_alias($txt);
         }
     } else {
         $txt = kona3show_file_not_found($page, $ext);
@@ -141,6 +142,30 @@ function kona3_action_show($actionMode = "")
         "is_login" => $is_login,
         "edit_button_html" => $edit_button_html,
     ]);
+}
+
+function kona3show_redirect_alias($txt)
+{
+    $target = kona3show_find_alias_target($txt);
+    if ($target === FALSE) {
+        return;
+    }
+    $url = kona3getPageURL($target, 'show');
+    header("location: $url");
+    echo "<a href='$url'>JUMP</a>";
+    exit;
+}
+
+function kona3show_find_alias_target($txt)
+{
+    if (!preg_match('/^\s*!!alias\s*\(\s*([^)]+?)\s*\)\s*$/m', $txt, $m)) {
+        return FALSE;
+    }
+    $target = trim($m[1]);
+    if ($target === '') {
+        return FALSE;
+    }
+    return $target;
 }
 
 function kona3show_check_private($page, $showLoginLink = TRUE)

--- a/kona3engine/kona3conf.inc.php
+++ b/kona3engine/kona3conf.inc.php
@@ -389,9 +389,6 @@ function kona3conf_setDatabase()
     if (!file_exists($file_info_sqlite)) { // rename old file
         // 古いDBファイルがあれば、新しいパスに移動する
         if (file_exists($old_file_info_sqlite)) {
-            // ファイルを異動する前にpage_idを移行する
-            kona3_conf_read_old_page_ids($old_file_info_sqlite);
-            @kona3db_getPageId(kona3getConf("FrontPage"), FALSE);
             // ファイルを移動する
             @rename($old_file_info_sqlite, $file_info_sqlite);
         }
@@ -446,8 +443,6 @@ function kona3_conf_read_old_page_ids($old_db_path)
             }
         }
         $pdo = null;
-        // save
-        kona3lock_save(KONA3_PAGE_ID_JSON, json_encode($kona3pageIds, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
     }
     return $kona3pageIds;
 }

--- a/kona3engine/kona3db.inc.php
+++ b/kona3engine/kona3db.inc.php
@@ -1,46 +1,47 @@
 <?php
 // file: kona3db.inc.php
 require_once __DIR__ . '/kona3conf.inc.php';
-// global
-global $kona3pageIds, $kona3pageIdCache;
-// init global
-$kona3pageIds = NULL;
-$kona3pageIdCache = NULL;
-
 // ページIDを取得する
 function kona3db_getPageId($page, $canCreate = FALSE)
 {
-    global $kona3pageIds, $kona3pageIdCache;
-    if ($kona3pageIds === NULL) {
-        // load KONA3_PAGE_ID_JSON
-        if (file_exists(KONA3_PAGE_ID_JSON)) {
-            $jsonData = kona3lock_load(KONA3_PAGE_ID_JSON);
-            $kona3pageIds = json_decode($jsonData, TRUE);
-        } else {
-            $kona3pageIds = [];
+    $r = db_get1(
+        "SELECT page_id FROM pages WHERE name=?",
+        [$page]
+    );
+    if ($r && isset($r['page_id'])) {
+        return intval($r['page_id']);
+    }
+    $legacy_page_ids = kona3db_loadLegacyPageIds();
+    if (isset($legacy_page_ids[$page])) {
+        $legacy_page_id = intval($legacy_page_ids[$page]);
+        $time = time();
+        db_exec(
+            "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
+            [$legacy_page_id, $page, $time, 0]
+        );
+        $r = db_get1(
+            "SELECT page_id FROM pages WHERE name=?",
+            [$page]
+        );
+        if ($r && isset($r['page_id'])) {
+            return intval($r['page_id']);
         }
     }
-    // return page id
-    if (isset($kona3pageIds[$page])) {
-        return $kona3pageIds[$page];
+    if (!$canCreate) {
+        return 0;
     }
-    // create page id
-    if ($canCreate) {
-        // page_idの最大値を得る
-        $maxId = 0;
-        foreach ($kona3pageIds as $_ => $id) {
-            if ($id > $maxId) {
-                $maxId = $id;
-            }
-        }
-        $kona3pageIds[$page] = $maxId + 1;
-        $saved = kona3lock_save(KONA3_PAGE_ID_JSON, json_encode($kona3pageIds, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
-        if (!$saved) {
-            unset($kona3pageIds[$page]);
-            return 0;
-        }
-        $kona3pageIdCache = NULL;
-        return $kona3pageIds[$page];
+
+    $time = time();
+    db_exec(
+        "INSERT OR IGNORE INTO pages (name, ctime, mtime) VALUES (?, ?, ?)",
+        [$page, $time, 0]
+    );
+    $r = db_get1(
+        "SELECT page_id FROM pages WHERE name=?",
+        [$page]
+    );
+    if ($r && isset($r['page_id'])) {
+        return intval($r['page_id']);
     }
     return 0;
 }
@@ -48,26 +49,53 @@ function kona3db_getPageId($page, $canCreate = FALSE)
 // ページIDから名前を取得する
 function kona3db_getPageNameById($page_id, $default = '')
 {
-    // load page_id
-    global $kona3pageIds;
-    global $kona3pageIdCache;
-    // load data
-    if ($kona3pageIds === NULL) {
-        // load
-        kona3db_getPageId(kona3getConf("FrontPage"), FALSE);
+    $r = db_get1(
+        "SELECT name FROM pages WHERE page_id=?",
+        [intval($page_id)]
+    );
+    if ($r && isset($r['name'])) {
+        return $r['name'];
     }
-    // make cache
-    if ($kona3pageIdCache === NULL) {
-        $kona3pageIdCache = [];
-        foreach ($kona3pageIds as $name => $id) {
-            $kona3pageIdCache[$id] = $name;
+    $legacy_page_ids = kona3db_loadLegacyPageIds();
+    foreach ($legacy_page_ids as $name => $id) {
+        if (intval($id) !== intval($page_id)) {
+            continue;
         }
-    }
-    // check cache
-    if (isset($kona3pageIdCache[$page_id])) {
-        return $kona3pageIdCache[$page_id];
+        $time = time();
+        db_exec(
+            "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
+            [intval($page_id), $name, $time, 0]
+        );
+        return $name;
     }
     return $default;
+}
+
+function kona3db_loadLegacyPageIds()
+{
+    static $legacy_page_ids = NULL;
+    if ($legacy_page_ids !== NULL) {
+        return $legacy_page_ids;
+    }
+    $legacy_page_ids = [];
+    if (!file_exists(KONA3_PAGE_ID_JSON)) {
+        return $legacy_page_ids;
+    }
+    $jsonData = kona3lock_load(KONA3_PAGE_ID_JSON);
+    $legacy_page_ids = kona3db_decodeLegacyPageIds($jsonData);
+    return $legacy_page_ids;
+}
+
+function kona3db_decodeLegacyPageIds($jsonData)
+{
+    if (!is_string($jsonData)) {
+        return [];
+    }
+    $data = json_decode($jsonData, TRUE);
+    if (!is_array($data)) {
+        return [];
+    }
+    return $data;
 }
 
 function kona3db_writePage($page, $body, $user_id = 0, $tags = NULL)

--- a/kona3engine/kona3lib.inc.php
+++ b/kona3engine/kona3lib.inc.php
@@ -872,34 +872,15 @@ function kona3_getEditTokenForm($page = 'default', $action = 'edit', $label = 'E
 
 function kona3getShortcutLink()
 {
-    // get url
-    $host = empty($_SERVER['HTTP_HOST']) ? "" : $_SERVER['HTTP_HOST'];
-    $scriptname = dirname($_SERVER['SCRIPT_NAME']);
-    // check last path
-    if (substr($scriptname, strlen($scriptname) - 1, 1) == '/') {
-        $scriptname = substr(0, strlen($scriptname) - 1);
-    }
-    $scheme = (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] === 'on')) ? 'https' : 'http';
-    $base_url = "{$scheme}://{$host}{$scriptname}/go.php";
-    // get shortcut
-    // get page_id
     $file_not_found = kona3getConf("page_not_found", FALSE);
     if ($file_not_found) {
         return '<!-- no shortcut -->';
     } else {
         $page = $_GET['page'];
-        $page_id = kona3db_getPageId($page);
     }
-    if ($page_id == 0) {
-        return '<!-- no shortcut -->';
-    }
-    $url = "{$base_url}?{$page_id}";
-    // get real url
     $real_url = kona3getPageURL($page);
     $page_h = htmlspecialchars($page, ENT_QUOTES);
-    return "" .
-        "<a href=\"$real_url\">$page_h</a>&nbsp;" .
-        "(<a href=\"$url\">{$page_id}</a>)";
+    return "<a href=\"$real_url\">$page_h</a>";
 }
 
 

--- a/kona3engine/plugins/alias.inc.php
+++ b/kona3engine/plugins/alias.inc.php
@@ -1,0 +1,16 @@
+<?php
+
+/** ページの別名を指定します。
+ * - [書式] !!alias(ジャンプ先)
+ */
+
+function kona3plugins_alias_execute($args)
+{
+    $page = trim(array_shift($args));
+    if ($page === '') {
+        return '';
+    }
+    $page_h = kona3text2html($page);
+    $url = kona3getPageURL($page, 'show');
+    return "<a href='$url'>$page_h</a>";
+}

--- a/kona3engine/tests/alias.test.php
+++ b/kona3engine/tests/alias.test.php
@@ -1,0 +1,20 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+require_once dirname(__DIR__) . '/action/show.inc.php';
+require_once dirname(__DIR__) . '/plugins/alias.inc.php';
+
+$target = kona3show_find_alias_target("!!alias(TargetPage)\n");
+test_eq(__LINE__, $target, "TargetPage", "alias target is detected");
+
+$target = kona3show_find_alias_target("# title\n\n!!alias( Japanese/Page )\n");
+test_eq(__LINE__, $target, "Japanese/Page", "alias target is trimmed");
+
+$target = kona3show_find_alias_target("!!alias()\n");
+test_eq(__LINE__, $target, FALSE, "empty alias target is ignored");
+
+$target = kona3show_find_alias_target("本文\n");
+test_eq(__LINE__, $target, FALSE, "non alias page is ignored");
+
+$html = kona3plugins_alias_execute(["TargetPage"]);
+test_assert(__LINE__, strpos($html, "TargetPage") !== FALSE, "alias plugin renders target label");
+test_assert(__LINE__, strpos($html, "href=") !== FALSE, "alias plugin renders a link");

--- a/kona3engine/tests/go.test.php
+++ b/kona3engine/tests/go.test.php
@@ -1,0 +1,8 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+require_once dirname(__DIR__) . '/action/go.inc.php';
+
+test_eq(__LINE__, kona3go_getRedirectURL(''), 'index.php', "empty go target redirects to index.php");
+test_eq(__LINE__, kona3go_getRedirectURL('FrontPage'), 'index.php?FrontPage&show', "go.php?FrontPage redirects to show action");
+test_eq(__LINE__, kona3go_getRedirectURL('Category/SubPage'), 'index.php?Category%2FSubPage&show', "go.php?sub page redirects to show action");
+test_eq(__LINE__, kona3go_getRedirectURL('日本語ページ'), 'index.php?' . urlencode('日本語ページ') . '&show', "go.php?Japanese page redirects to show action");

--- a/kona3engine/tests/kona3db.test.php
+++ b/kona3engine/tests/kona3db.test.php
@@ -3,11 +3,6 @@ require_once __DIR__ . '/test_common.inc.php';
 
 // --- データベース層のテスト ---
 
-// グローバル変数の初期化
-global $kona3pageIds, $kona3pageIdCache;
-$kona3pageIds = NULL;
-$kona3pageIdCache = NULL;
-
 // --- ページIDの管理テスト ---
 
 // 新しいページIDの作成（テストページ1）

--- a/kona3engine/tests/page_id.test.php
+++ b/kona3engine/tests/page_id.test.php
@@ -2,13 +2,28 @@
 require_once __DIR__ . '/test_common.inc.php';
 
 // page_id test
+test_assert(__LINE__, kona3db_decodeLegacyPageIds(FALSE) === [], "legacy page ID load failure is treated as an empty map");
+test_assert(__LINE__, kona3db_decodeLegacyPageIds('') === [], "empty legacy page ID JSON is treated as an empty map");
+test_assert(__LINE__, kona3db_decodeLegacyPageIds('{"LegacyPage":123}') === ["LegacyPage" => 123], "legacy page ID JSON is decoded");
+
 $page = "PageIdTest_" . time();
+$page_id_file = KONA3_PAGE_ID_JSON;
+$before_exists = file_exists($page_id_file);
+$before_mtime = $before_exists ? filemtime($page_id_file) : FALSE;
+$before_hash = $before_exists ? hash_file('sha256', $page_id_file) : FALSE;
+
 $page_id = kona3db_getPageId($page, TRUE);
-test_assert(__LINE__, is_numeric($page_id) && $page_id > 0, "kona3db_getPageId creates a page ID");
-test_eq(__LINE__, kona3db_getPageId($page, FALSE), $page_id, "kona3db_getPageId returns the same ID for an existing page");
+test_assert(__LINE__, is_numeric($page_id) && $page_id > 0, "kona3db_getPageId creates an internal page ID");
+test_eq(__LINE__, kona3db_getPageId($page, FALSE), $page_id, "kona3db_getPageId returns the same internal ID");
 test_eq(__LINE__, kona3db_getPageNameById($page_id), $page, "kona3db_getPageNameById returns the created page name");
+test_eq(__LINE__, file_exists($page_id_file), $before_exists, "kona3db_getPageId does not create .kona3_page_id.json");
+if ($before_exists) {
+    clearstatcache(TRUE, $page_id_file);
+    test_eq(__LINE__, filemtime($page_id_file), $before_mtime, "kona3db_getPageId does not touch .kona3_page_id.json mtime");
+    test_eq(__LINE__, hash_file('sha256', $page_id_file), $before_hash, "kona3db_getPageId does not modify .kona3_page_id.json");
+}
 
 $cached_page = "PageIdCacheTest_" . time();
 $cached_id = kona3db_getPageId($cached_page, TRUE);
-test_assert(__LINE__, is_numeric($cached_id) && $cached_id > 0, "kona3db_getPageId creates a page ID after reverse lookup cache exists");
-test_eq(__LINE__, kona3db_getPageNameById($cached_id), $cached_page, "kona3db_getPageNameById sees newly created IDs after cache invalidation");
+test_assert(__LINE__, is_numeric($cached_id) && $cached_id > 0, "kona3db_getPageId creates an internal ID after reverse lookup");
+test_eq(__LINE__, kona3db_getPageNameById($cached_id), $cached_page, "kona3db_getPageNameById sees newly created internal IDs");


### PR DESCRIPTION
## 変更内容

- `data/.kona3_page_id.json` へのページID保存を廃止し、内部IDはSQLite `pages` テーブルへ保存するようにしました。
- 既存の `.kona3_page_id.json` は読み取り専用の互換移行元として扱い、必要な対応だけSQLiteへ取り込みます。
- `go` アクションのIDジャンプを削除し、`go.php?ページ名` は `index.php?ページ名&show` へリダイレクトするようにしました。
- `!!alias(ジャンプ先)` を表示前に検出して対象ページへリダイレクトする処理を追加しました。
- `alias` プラグインと回帰テストを追加しました。

## レビュー対応

- `kona3lock_load()` が `FALSE` を返した場合に `json_decode()` へ渡さず、空のlegacy page ID mapとして扱うようにしました。

## 背景

Issue #182 の要件に沿って、Git同期時に衝突しやすい `.kona3_page_id.json` の作成・更新を止め、IDジャンプ機能を廃止します。

## 検証

- `php -l kona3engine/kona3db.inc.php`
- `php -l kona3engine/kona3conf.inc.php`
- `php -l kona3engine/action/go.inc.php`
- `php -l kona3engine/action/show.inc.php`
- `php -l kona3engine/plugins/alias.inc.php`
- `php -l kona3engine/tests/alias.test.php`
- `php -l kona3engine/tests/go.test.php`
- `php -l kona3engine/tests/page_id.test.php`
- `php kona3engine/tests/page_id.test.php`
- `php kona3engine/tests/alias.test.php`
- `php kona3engine/tests/go.test.php`
- `php kona3engine/tests/kona3db.test.php`
- `just test` 613/613 成功

既存テスト由来の header Warning と配列比較 Warning は残っていますが、テスト結果は成功です。