### PR TITLE
[codex] Fix comment plugin posting and moderation

### DIFF
--- a/kona3engine/plugins/comment.inc.php
+++ b/kona3engine/plugins/comment.inc.php
@@ -1,9 +1,20 @@
 <?php
-/** 簡易コメント掲示板を追加
- * - [書式] #comment(id=bbsid,type=***) 
- * - [引数]
- * -- id=*** ... 掲示板のID
- * -- type=*** ... 掲示板のタイプ(allで全部表示/todoでTODOのもの)
+/**
+ * 簡易コメント掲示板を追加
+ *
+ * - 書式: #comment(id=bbsid,type=***,loginOnly)
+ * - id=***: 掲示板のIDを指定する。省略時は現在のページ名を使う。
+ * - type=all: 全ページのコメント一覧を表示する。
+ * - type=todo: 全ページの未完了(todo)コメント一覧を表示する。
+ * - loginOnly: 未ログイン時は投稿フォームを隠し、ログイン案内とログインリンクを表示する。
+ * - 通常のコメント欄には、全ページのコメントを管理する comment list リンクを表示する。
+ * - 未ログイン投稿では、従来どおり名前と削除パスワードの入力欄を表示する。
+ * - ログイン済み投稿では、名前と削除パスワードの入力を省略し、ログインユーザー名とuser_idを保存する。
+ * - 未ログイン投稿の削除は、投稿時の削除パスワードまたは掲示板管理パスワードで行う。
+ * - [del]リンクを押した時は、削除前に確認画面を表示する。
+ * - ログイン済みユーザーは、自分の投稿を削除パスワードなしで削除できる。
+ * - ログイン済みユーザーが他人の投稿を削除しようとした場合、管理ユーザーへの依頼を促す。
+ * - 管理ユーザーは、すべてのコメントを削除パスワードなしで削除できる。
 */
 function kona3plugins_comment_execute($params) {
   global $kona3conf;
@@ -11,12 +22,17 @@ function kona3plugins_comment_execute($params) {
   $page = $kona3conf['page'];
   $bbsid = $page;
   $type = "";
+  $loginOnly = FALSE;
   $pdo = database_get();
   if (!$pdo) {
     return "([#comment] SQLite could not use...)";
   }
   // check params     
   foreach ($params as $s) {
+    if ($s == 'loginOnly') {
+      $loginOnly = TRUE;
+      continue;
+    }
     if (!preg_match('#^(\w+?)\=(.+)$#', $s, $m)) continue;
     list($match, $key, $val) = $m;
     if ($key == "id") {
@@ -27,12 +43,22 @@ function kona3plugins_comment_execute($params) {
       $type = $val;
       continue;
     }
+    if ($key == "loginOnly") {
+      $loginOnly = ($val != '' && $val != '0' && strtolower($val) != 'false');
+      continue;
+    }
   }
   // check table exists?
   kona3plugins_comment_init_db($pdo);
   if ($type == "all") {
+    if (!kona3isLogin()) {
+      return _renderCommentLoginRequired($page);
+    }
     return _at_all($pdo, 'all');
   } else if ($type == "todo") {
+    if (!kona3isLogin()) {
+      return _renderCommentLoginRequired($page);
+    }
     return _at_all($pdo, 'todo');
   }
   // select logs
@@ -44,11 +70,15 @@ function kona3plugins_comment_execute($params) {
   $stmt->execute(array(intval($bbs_id)));
   $logs = $stmt->fetchAll();
   // render logs
+  $html_header = _renderCommentHeader($page);
   $html_comments = _renderCommentList($page, $logs);
-  $html_form = _renderCommentForm($page, $bbs_id);
+  $html_form = ($loginOnly && !kona3isLogin())
+    ? _renderCommentLoginRequired($page)
+    : _renderCommentForm($page, $bbs_id);
   return <<<__EOS__
 <!-- #comment plugin -->
 <div class="plugin_comment">
+  {$html_header}
   <div class='comment_box'>
     {$html_comments}
   </div><!-- end of .comment_box -->
@@ -59,20 +89,30 @@ function kona3plugins_comment_execute($params) {
 __EOS__;
 }
 
-function _renderCommentList($page, $logs) {
-  if (!$logs) return "";
-  $html = <<<__EOS__
+function _renderCommentHeader($page) {
+  $comment_list_url = htmlspecialchars(
+    kona3getPageURL($page, 'plugin', '', 'name=comment&m=list'),
+    ENT_QUOTES | ENT_SUBSTITUTE,
+    'UTF-8'
+  );
+  return <<<__EOS__
 <!-- title -->
 <div class='plugin_title'>
   <a name='CommentBox'>#comment</a>
+  <span class='memo'>[<a href='{$comment_list_url}'>comment list</a>]</span>
 </div>
 __EOS__;
+}
+
+function _renderCommentList($page, $logs) {
+  if (!$logs) return "";
+  $html = "";
   $index = kona3getPageURL($page, 'plugin', '', 'name=comment');
   $index .= "&";
   foreach ($logs as $row) {
-    $id = $row["comment_id"];
-    $name = htmlentities($row['name']);
-    $body = htmlentities($row['body']);
+    $id = intval($row["comment_id"]);
+    $name = htmlspecialchars($row['name'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $body = htmlspecialchars($row['body'], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     $body = str_replace("\n", "<br>", $body);
     $body = str_replace(" ", "&nbsp;", $body);
     $body = preg_replace(
@@ -81,10 +121,11 @@ __EOS__;
       $body);
     $mtime = ($row['mtime'] == 0)
       ? "-" : date("Y-m-d H:i", $row['mtime']);
-    $del = "<a href='{$index}m=del&id=$id'>del</a>";
+    $del_url = htmlspecialchars($index."m=del&id=$id", ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $del = "<a href='{$del_url}'>del</a>";
     $todo_v = $row['todo'];
     $todo_l = ($todo_v == 0) ? "done" : "todo";
-    $todo = "<a class='$todo_l' onclick='chtodo(event,$id)'>$todo_l</a>";
+    $todo = kona3plugins_comment_renderTodoControl($todo_l, $id);
     $html .= <<<__EOS__
 <!-- logs -->
 <div class='comment_log'>
@@ -107,7 +148,29 @@ function _renderCommentForm($page, $bbs_id) {
   $msg_post_comment = lang('Post Comment');
   $msg_close = lang('Close');
   $msg_post = lang('Add');
-  $edit_token = kona3_getEditToken();
+  $bbs_id = intval($bbs_id);
+  $edit_token = htmlspecialchars(kona3_getEditToken('edit_token'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $form_action = htmlspecialchars($form_action, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $login_info = kona3getLoginInfo();
+  $user_name = $login_info ? kona3getUserName() : '';
+  $user_name_html = htmlspecialchars($user_name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $user_name_input = htmlspecialchars($user_name, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $account_fields = $login_info
+    ? <<< EOS
+    <input type="hidden" name="name" value="$user_name_input">
+    <input type="hidden" name="pw" value="">
+    <p class="memo">name: {$user_name_html}</p>
+EOS
+    : <<< EOS
+    <label for="kona3comment_name">
+      name:
+      <input id="kona3comment_name" type="text" name="name" value="" autocomplete="name">
+    </label>
+    <label for="kona3comment_password">
+      password
+      <input id="kona3comment_password" type="password" name="pw" value="">
+    </label>
+EOS;
   return <<< EOS
 <div class="comment_form_box">
   <!-- close bar -->
@@ -122,18 +185,11 @@ function _renderCommentForm($page, $bbs_id) {
     <input type="hidden" name="m" value="write">
     <input type="hidden" name="bbs_id" value="$bbs_id">
     <input type="hidden" id="edit_token" name="edit_token" value="$edit_token">
-    <label for="kona3comment_name">
-      name:
-      <input id="kona3comment_name" type="text" name="name" value="" autocomplete="name">
-    </label>
+    {$account_fields}
     <label for="kona3comment_body">
       body:
       <span class="memo">(&gt;1 &gt;2 ...)</span>
       <textarea id="kona3comment_body" name="body" rows="4" cols="50"></textarea>
-    </label>
-    <label for="kona3comment_password">
-      password
-      <input id="kona3comment_password" type="password" name="pw" value="">
     </label>
     <input class="pure-button pure-button-primary" type="submit" value="$msg_post">
   </form>
@@ -144,6 +200,26 @@ function _renderCommentForm($page, $bbs_id) {
    onclick='comment_form_open()'>
       →{$msg_post_comment}</a>
 </div><!-- end of .msg_post_comment -->
+{$script}\n
+EOS;
+}
+
+function _renderCommentLoginRequired($page) {
+  $script = _todo_script();
+  $edit_token = htmlspecialchars(kona3_getEditToken('edit_token'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $login_url = htmlspecialchars(
+    kona3getPageURL($page, 'login'),
+    ENT_QUOTES | ENT_SUBSTITUTE,
+    'UTF-8'
+  );
+  $msg = htmlspecialchars(lang('Please login.'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $login = htmlspecialchars(lang('Login'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  return <<< EOS
+<div class="comment_login_required">
+  <input type="hidden" id="edit_token" name="edit_token" value="{$edit_token}">
+  <p>{$msg}</p>
+  <p><a class="pure-button pure-button-primary" href="{$login_url}">{$login}</a></p>
+</div>
 {$script}\n
 EOS;
 }
@@ -181,6 +257,19 @@ function kona3plugins_comment_action() {
   $output_format = kona3param("fmt", ""); 
   $is_login = kona3isLogin();
   if ($m == "") _err($page, 'No Mode in Comment'); 
+  // show comment list
+  if ($m == "list") {
+    if (!kona3isLogin()) {
+      kona3showMessage('Comments', _renderCommentLoginRequired($page));
+      return;
+    }
+    $type = kona3param("type", "all");
+    if ($type != "todo") $type = "all";
+    $pdo = database_get();
+    kona3plugins_comment_init_db($pdo);
+    kona3showMessage('Comments', _renderCommentAdminPage($pdo, $type));
+    return;
+  }
   // write comment
   if ($m == "write") {
     kona3plugins_comment_action_write($page);
@@ -189,22 +278,38 @@ function kona3plugins_comment_action() {
   // delete comment (1/2)
   if ($m == "del") {
     $id = intval(@$_REQUEST['id']);
-    $edit_token = kona3_getEditToken();
+    $edit_token = kona3_getEditToken('edit_token');
     if ($id <= 0) kona3error($page, 'no id');
-    $del_form = "<form method='post'>".
-      "<input type='hidden' name='edit_token' value='$edit_token'>".
-      "<input type='hidden' name='m' value='del2'>".
-      "<input type='hidden' name='id' value='$id'>".
-      "<p>".lang('Really?')."</p>".
-      "<p>".lang("Password").": <input type='password' name='pw' value=''></p>".
-      "<input class='pure-button pure-button-primary' type='submit' value='".lang('Delete')."'></p>".
-      "</form>";
-    kona3showMessage(lang('Delete')." (id:$id)", $del_form);
+    $pdo = database_get();
+    kona3plugins_comment_init_db($pdo);
+    $row = kona3plugins_comment_getComment($pdo, $id);
+    if (!$row) {
+      kona3error($page, 'Comment not found');
+      exit;
+    }
+    if (kona3isLogin()) {
+      if (kona3plugins_comment_canDeleteAsLoginUser($row)) {
+        kona3showMessage(
+          lang('Delete')." (id:$id)",
+          kona3plugins_comment_renderDeleteForm($id, $edit_token, FALSE)
+        );
+        exit;
+      }
+      kona3showMessage(
+        lang('Delete'),
+        '管理ユーザーに削除を依頼するようにしてください。'
+      );
+      exit;
+    }
+    kona3showMessage(
+      lang('Delete')." (id:$id)",
+      kona3plugins_comment_renderDeleteForm($id, $edit_token, TRUE)
+    );
     exit;
   }
   // delete comment (2/2)
   if ($m == "del2") {
-    if (!kona3_checkEditToken()) {
+    if (!kona3_checkEditToken('edit_token')) {
       kona3error(lang('Invalid Token'), lang('Invalid edit token.'));
       exit;
     }
@@ -215,40 +320,40 @@ function kona3plugins_comment_action() {
       exit;
     }
     $pdo = database_get();
-    $stmt = $pdo->prepare('SELECT * FROM comment_list WHERE comment_id=?');
-    $stmt->execute(array($id));
-    $row = $stmt->fetch();
-    // check password hash
-    $delkey = $row['delkey'];
-    $can_delete = hash_equals($delkey, $pw); // for old password
-    if (substr($delkey, 0, 2) == '!!') {
-      list($type, $salt, $hash) = explode('::', $delkey);
-      if ($type != '!!sha256') {
-        kona3error('system error', 'invalid hash type');
-        exit;
-      }
-      $can_delete = hash_equals(
-        kona3plugins_comment_getHash($pw, $salt),
-        $hash);
-      if (!$can_delete) {
-        $bbs_admin_password = kona3getConf('bbs_admin_password', '');
-        if ($bbs_admin_password != '') {
-          if ($pw == $bbs_admin_password) { $can_delete = TRUE; }
-        }
-      }
+    kona3plugins_comment_init_db($pdo);
+    $row = kona3plugins_comment_getComment($pdo, $id);
+    if (!$row) {
+      kona3error($page, 'Comment not found');
+      exit;
     }
+    if (kona3isLogin() && !kona3plugins_comment_canDeleteAsLoginUser($row)) {
+      kona3showMessage(
+        lang('Delete'),
+        '管理ユーザーに削除を依頼するようにしてください。'
+      );
+      exit;
+    }
+    $can_delete = kona3isLogin()
+      ? kona3plugins_comment_canDeleteAsLoginUser($row)
+      : kona3plugins_comment_checkDeletePassword($row, $pw);
     // delete
     if (!$can_delete) {
       kona3error($page, 'Invalid Password');
       exit;
     }
-    $pdo->exec("DELETE FROM comment_list WHERE comment_id=$id");
+    kona3plugins_comment_deleteComment($pdo, $id);
     if ($output_format == "json") _ok($page, "deleted");
-    header('location: index.php?'.urlencode($page));
+    if (!headers_sent()) {
+      header('location: index.php?'.urlencode($page));
+    }
+    return;
   }
   // set todo
   if ($m == "todo") {
-    if (!kona3_checkEditToken()) {
+    if (!kona3isLogin()) {
+      _err($page, 'Please login.'); exit;
+    }
+    if (!kona3_checkEditToken('edit_token')) {
       _err($page, 'Invalid Token'); exit;
     }
     $id = intval(@$_REQUEST['id']);
@@ -275,7 +380,7 @@ function kona3plugins_comment_action_write($page) {
   $pw   = isset($_POST['pw']) ? $_POST['pw'] : '';
 
   // check edit_token
-  if (!kona3_checkEditToken()) {
+  if (!kona3_checkEditToken('edit_token')) {
     kona3error(lang('Invalid Token'), '<a href="javascript:history.back()">'.lang('Please back page.').'</a>'); exit;
   }
   // check paramters
@@ -283,22 +388,30 @@ function kona3plugins_comment_action_write($page) {
   if ($body == '' || $bbs_id <= 0) {
     _err($page, 'Invalid data'); exit;
   }
+  if (kona3isLogin()) {
+    $name = kona3getUserName();
+    $pw = '';
+  }
+  $user_id = kona3isLogin() ? intval(kona3getUserId()) : 0;
   if ($name == '') $name = 'no name';
   // make hash for salt
   $salt = bin2hex(random_bytes(32));
   $pw_hash = "!!sha256::".$salt."::".kona3plugins_comment_getHash($pw, $salt);
   $pdo = database_get();
+  kona3plugins_comment_init_db($pdo);
   $stmt = $pdo->prepare(
-    "INSERT INTO comment_list(bbs_id, name, body, delkey, ctime, mtime)".
-    "VALUES(?, ?, ?, ?, ?, ?)".
+    "INSERT INTO comment_list(bbs_id, name, body, delkey, user_id, ctime, mtime)".
+    "VALUES(?, ?, ?, ?, ?, ?, ?)".
     "");
-  $a = array($bbs_id, $name, $body, $pw_hash, time(), time());
+  $a = array($bbs_id, $name, $body, $pw_hash, $user_id, time(), time());
   $r = $stmt->execute($a);
   
   // show result
   if ($output_format == "json") _ok($page, "inserted"); 
   // jump
-  header("location: index.php?".urlencode($page));
+  if (!headers_sent()) {
+    header("location: index.php?".urlencode($page));
+  }
 }
 
 function kona3plugins_comment_getHash($pw, $salt) {
@@ -306,29 +419,123 @@ function kona3plugins_comment_getHash($pw, $salt) {
 }
 
 function kona3plugins_comment_init_db($pdo) {
-  if (db_table_exists("comment_list")) {
-    return;
-  }
-  $sql = <<< EOS
-    /* comment table */
+  if (!db_table_exists("comment_list")) {
+    $sql = <<< EOS
     CREATE TABLE IF NOT EXISTS comment_list (
       comment_id INTEGER PRIMARY KEY,
       bbs_id INTEGER DEFAULT 0,
       name TEXT DEFAULT 'no name',
       body TEXT DEFAULT '',
       delkey TEXT DEFAULT '',
+      user_id INTEGER DEFAULT 0,
       res_id INTEGER DEFAULT 0,
       todo INTEGER DEFAULT 1, /* 0:done 1:to do */  
       ctime INTEGER,
       mtime INTEGER
     );
-    /* id to bbs_id */
+EOS;
+    $pdo->exec($sql);
+  }
+  if (!kona3plugins_comment_tableHasColumn($pdo, 'comment_list', 'user_id')) {
+    $pdo->exec('ALTER TABLE comment_list ADD COLUMN user_id INTEGER DEFAULT 0');
+  }
+  if (!db_table_exists("comment_bbsid")) {
+    $sql = <<< EOS
     CREATE TABLE IF NOT EXISTS comment_bbsid(
       bbs_id INTEGER PRIMARY KEY,
       name TEXT DEFAULT ''
     );
 EOS;
-  $pdo->exec($sql);
+    $pdo->exec($sql);
+  }
+}
+
+function kona3plugins_comment_tableHasColumn($pdo, $table, $column) {
+  $stmt = $pdo->query('PRAGMA table_info('.$table.')');
+  $rows = $stmt->fetchAll();
+  foreach ($rows as $row) {
+    if (isset($row['name']) && $row['name'] == $column) {
+      return TRUE;
+    }
+  }
+  return FALSE;
+}
+
+function kona3plugins_comment_getComment($pdo, $id) {
+  $stmt = $pdo->prepare('SELECT * FROM comment_list WHERE comment_id=?');
+  $stmt->execute(array(intval($id)));
+  return $stmt->fetch();
+}
+
+function kona3plugins_comment_deleteComment($pdo, $id) {
+  $stmt = $pdo->prepare('DELETE FROM comment_list WHERE comment_id=?');
+  return $stmt->execute(array(intval($id)));
+}
+
+function kona3plugins_comment_renderDeleteForm($id, $edit_token, $require_password) {
+  $id = intval($id);
+  $edit_token = htmlspecialchars($edit_token, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $password_html = '';
+  if ($require_password) {
+    $password_html =
+      "<p>".lang("Password").": <input type='password' name='pw' value=''></p>";
+  }
+  return "<form method='post'>".
+    "<input type='hidden' name='edit_token' value='$edit_token'>".
+    "<input type='hidden' name='m' value='del2'>".
+    "<input type='hidden' name='id' value='$id'>".
+    "<p>".lang('Really?')."</p>".
+    $password_html.
+    "<input class='pure-button pure-button-primary' type='submit' value='".lang('Delete')."'></p>".
+    "</form>";
+}
+
+function kona3plugins_comment_canDeleteAsLoginUser($row) {
+  if (kona3isAdmin()) {
+    return TRUE;
+  }
+  if (!kona3isLogin()) {
+    return FALSE;
+  }
+  $comment_user_id = isset($row['user_id']) ? intval($row['user_id']) : 0;
+  if ($comment_user_id <= 0) {
+    return FALSE;
+  }
+  return $comment_user_id === intval(kona3getUserId());
+}
+
+function kona3plugins_comment_checkDeletePassword($row, $pw) {
+  $delkey = isset($row['delkey']) ? $row['delkey'] : '';
+  $can_delete = hash_equals($delkey, $pw); // for old password
+  if (substr($delkey, 0, 2) == '!!') {
+    $parts = explode('::', $delkey);
+    if (count($parts) !== 3) {
+      return FALSE;
+    }
+    list($type, $salt, $hash) = $parts;
+    if ($type != '!!sha256') {
+      return FALSE;
+    }
+    $can_delete = hash_equals(
+      kona3plugins_comment_getHash($pw, $salt),
+      $hash);
+    if (!$can_delete) {
+      $bbs_admin_password = kona3getConf('bbs_admin_password', '');
+      if ($bbs_admin_password != '') {
+        if ($pw == $bbs_admin_password) { $can_delete = TRUE; }
+      }
+    }
+  }
+  return $can_delete;
+}
+
+function kona3plugins_comment_renderTodoControl($label, $id) {
+  $label = ($label == 'done') ? 'done' : 'todo';
+  $id = intval($id);
+  if (!kona3isLogin()) {
+    return "<span class='$label'>$label</span>";
+  }
+  return "<a class='$label' onclick='chtodo(event,$id)'>$label</a>";
 }
 
 function kona3plugins_comment_getBbsId($pdo, $name) {
@@ -348,13 +555,15 @@ function kona3plugins_comment_getBbsId($pdo, $name) {
 
 function _at_all($pdo, $type) {
   $page = kona3getPage();
+  $edit_token = htmlspecialchars(kona3_getEditToken('edit_token'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
   $q = $pdo->query('SELECT * FROM comment_bbsid');
   $allbbs = $q->fetchAll();
-  $html = "<h3>Comments (type=$type)</h3>";
+  $html = "<input type='hidden' id='edit_token' name='edit_token' value='{$edit_token}'>\n";
   foreach ($allbbs as $row) {
     $bbs_id = $row["bbs_id"];
-    $bbs_name = htmlentities($row["name"]);
+    $bbs_name = htmlspecialchars($row["name"], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     $link = kona3getPageURL($row["name"]);
+    $link_html = htmlspecialchars($link, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     $where = "";
     if ($type == "todo") {
       $where = " AND todo=1";
@@ -367,19 +576,19 @@ function _at_all($pdo, $type) {
     $stmt->execute(array($bbs_id));
     $list = $stmt->fetchAll();
     if (count($list) == 0) continue;
-    $html .= "<h4><a href='$link#CommentBox'>$bbs_name</a></h4>";
+    $html .= "<h4><a href='{$link_html}#CommentBox'>$bbs_name</a></h4>";
     $html .= "<ul>";
     $index = "index.php?".urlencode($page)."&plugin&name=comment";
     foreach ($list as $row) {
-      $id = $row["comment_id"];
-      $name = htmlentities($row["name"]);
-      $body = htmlentities(mb_substr($row["body"],0, 100));
+      $id = intval($row["comment_id"]);
+      $name = htmlspecialchars($row["name"], ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+      $body = htmlspecialchars(mb_substr($row["body"],0, 100), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
       $mtime = date("m-d H:i", $row["mtime"]);
       $todo_v = $row["todo"];
       $todo_l = ($todo_v == 0) ? "done" : "todo";
-      $todo = "(<a class='$todo_l' onclick='chtodo(event,$id,$todo_v)'>$todo_l</a>)";
+      $todo = "(".kona3plugins_comment_renderTodoControl($todo_l, $id).")";
       $html .= "<li>".
-        "<a href='{$link}#comment_id_{$id}'>($id)</a>".
+        "<a href='{$link_html}#comment_id_{$id}'>($id)</a>".
         "$name - $body ".
         "<span class='memo'>$mtime {$todo}</span>".
         "</li>\n";
@@ -390,20 +599,47 @@ function _at_all($pdo, $type) {
   return $html;
 }
 
+function _renderCommentAdminPage($pdo, $type) {
+  $page = kona3getPage();
+  $all_url = htmlspecialchars(
+    kona3getPageURL($page, 'plugin', '', 'name=comment&m=list&type=all'),
+    ENT_QUOTES | ENT_SUBSTITUTE,
+    'UTF-8'
+  );
+  $todo_url = htmlspecialchars(
+    kona3getPageURL($page, 'plugin', '', 'name=comment&m=list&type=todo'),
+    ENT_QUOTES | ENT_SUBSTITUTE,
+    'UTF-8'
+  );
+  $title = htmlspecialchars("Comments (type=$type)", ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+  $list = _at_all($pdo, $type);
+  return <<<__EOS__
+<div class="plugin_comment">
+  <div class='plugin_title'>
+    <a name='CommentBox'>{$title}</a>
+    <span class='memo'>[<a href='{$all_url}'>all</a>] [<a href='{$todo_url}'>todo</a>]</span>
+  </div>
+  {$list}
+</div>
+__EOS__;
+}
+
 function _todo_script() {
   global $kona3conf;
   // do not use double
-  global $kona3_todo_script;
-  if ($kona3_comment_todo_script === TRUE) return "";
+  global $kona3_comment_todo_script;
+  if (isset($kona3_comment_todo_script) && $kona3_comment_todo_script === TRUE) return "";
   $kona3_comment_todo_script =TRUE;
   //
   $page = $kona3conf['page'];
-  $action = "index.php?".urlencode($page)."&plugin&name=comment";
+  $action = kona3getPageURL($page, 'plugin', '', 'name=comment');
+  $action_json = json_encode($action, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
   $script = <<< 'EOS'
 function chtodo(event, id) {
   var e = event.target;
   var v = (e.innerHTML == "todo") ? 1 : 0;
-  cv = (v == 0) ? 1 : 0;
+  var cv = (v == 0) ? 1 : 0;
+  event.preventDefault();
   var edit_token = qq("#edit_token").val();
   var para = {"m": "todo", "id": id, "v": cv, "fmt": "json", "edit_token": edit_token};
   qq().post(comment_api, para, function(data){
@@ -433,12 +669,9 @@ function comment_form_close() {
 EOS;
   $script = <<< EOS
 <script type="text/javascript">
-var comment_api = "$action";
+var comment_api = {$action_json};
 {$script}
 </script>
 EOS;
   return $script;
 }
-
-
-

--- a/kona3engine/tests/comment.test.php
+++ b/kona3engine/tests/comment.test.php
@@ -1,0 +1,155 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+require_once __DIR__ . '/../plugins/comment.inc.php';
+
+global $kona3conf, $FW_DB_INFO, $kona3_comment_todo_script;
+
+$original_db_info = isset($FW_DB_INFO['main']) ? $FW_DB_INFO['main'] : null;
+$tmp_db = tempnam(sys_get_temp_dir(), 'kona3_comment_');
+$tmp_sql = tempnam(sys_get_temp_dir(), 'kona3_comment_sql_');
+file_put_contents($tmp_sql, '/* comment plugin test */');
+database_set($tmp_db, $tmp_sql);
+
+$kona3conf['page'] = 'CommentTest';
+$kona3conf['FrontPage'] = 'FrontPage';
+$kona3conf['url.index'] = 'index.php';
+$_SESSION = [];
+
+$pdo = database_get();
+kona3plugins_comment_init_db($pdo);
+test_assert(__LINE__, db_table_exists('comment_list'), 'commentプラグイン: comment_listを作成');
+test_assert(__LINE__, db_table_exists('comment_bbsid'), 'commentプラグイン: comment_bbsidを作成');
+
+$pdo->exec('DROP TABLE comment_bbsid');
+kona3plugins_comment_init_db($pdo);
+test_assert(__LINE__, db_table_exists('comment_bbsid'), 'commentプラグイン: comment_bbsid欠落を復旧');
+
+$pdo->exec('DROP TABLE comment_list');
+$pdo->exec(
+    'CREATE TABLE comment_list (' .
+    'comment_id INTEGER PRIMARY KEY, bbs_id INTEGER DEFAULT 0, name TEXT DEFAULT "no name", ' .
+    'body TEXT DEFAULT "", delkey TEXT DEFAULT "", res_id INTEGER DEFAULT 0, todo INTEGER DEFAULT 1, ' .
+    'ctime INTEGER, mtime INTEGER)'
+);
+kona3plugins_comment_init_db($pdo);
+test_assert(__LINE__, kona3plugins_comment_tableHasColumn($pdo, 'comment_list', 'user_id'), 'commentプラグイン: 既存comment_listにuser_id列を追加');
+
+$bbs_id = kona3plugins_comment_getBbsId($pdo, 'CommentTest');
+$stmt = $pdo->prepare(
+    'INSERT INTO comment_list(bbs_id, name, body, delkey, ctime, mtime) VALUES(?, ?, ?, ?, ?, ?)'
+);
+$stmt->execute([$bbs_id, 'Alice & Bob', "hello <world>\n>1", '', 100, 100]);
+
+$html = kona3plugins_comment_execute([]);
+test_assert(__LINE__, strpos($html, 'plugin_comment') !== FALSE, 'commentプラグイン: HTMLを生成');
+test_assert(__LINE__, strpos($html, 'name=comment&amp;m=list') !== FALSE, 'commentプラグイン: コメント一覧リンクを表示');
+test_assert(__LINE__, strpos($html, 'Alice &amp; Bob') !== FALSE, 'commentプラグイン: 名前をエスケープ');
+test_assert(__LINE__, strpos($html, 'hello&nbsp;&lt;world&gt;<br><a href="#comment_id_1">&gt;1</a>') !== FALSE, 'commentプラグイン: 本文をエスケープして改行を表示');
+test_assert(__LINE__, strpos($html, 'href="#comment_id_1"') !== FALSE, 'commentプラグイン: 返信リンクを生成');
+test_assert(__LINE__, strpos($html, "href='index.php?CommentTest&amp;plugin&amp;name=comment&amp;m=del&amp;id=1'") !== FALSE, 'commentプラグイン: delリンクURLをHTMLエスケープ');
+test_assert(__LINE__, strpos($html, "href='index.php?CommentTest&plugin&name=comment&m=del&id=1'") === FALSE, 'commentプラグイン: delリンクURLに未エスケープの&を出力しない');
+test_assert(__LINE__, strpos($html, "<span class='todo'>todo</span>") !== FALSE, 'commentプラグイン: 未ログイン時はtodoをクリック不可にする');
+test_assert(__LINE__, strpos($html, "onclick='chtodo") === FALSE, 'commentプラグイン: 未ログイン時はtodo操作を出力しない');
+test_assert(__LINE__, strpos($html, 'id="kona3comment_name"') !== FALSE, 'commentプラグイン: 未ログイン時は名前入力を表示');
+test_assert(__LINE__, strpos($html, 'id="kona3comment_password"') !== FALSE, 'commentプラグイン: 未ログイン時はパスワード入力を表示');
+test_assert(__LINE__, preg_match('/name="edit_token" value="([^"]+)"/', $html, $m) === 1, 'commentプラグイン: edit_tokenをフォームに埋め込む');
+$_POST['edit_token'] = $m[1];
+test_assert(__LINE__, kona3_checkEditToken('edit_token'), 'commentプラグイン: 投稿フォームのedit_tokenを検証できる');
+unset($_POST['edit_token']);
+
+kona3login('Login User', 'login@example.com', 'normal', 1001);
+$login_html = kona3plugins_comment_execute([]);
+test_assert(__LINE__, strpos($login_html, 'id="kona3comment_name"') === FALSE, 'commentプラグイン: ログイン時は名前入力を省略');
+test_assert(__LINE__, strpos($login_html, 'id="kona3comment_password"') === FALSE, 'commentプラグイン: ログイン時はパスワード入力を省略');
+test_assert(__LINE__, strpos($login_html, 'name="name" value="Login User"') !== FALSE, 'commentプラグイン: ログインユーザー名をhiddenで送信');
+test_assert(__LINE__, strpos($login_html, 'name: Login User') !== FALSE, 'commentプラグイン: ログインユーザー名を表示');
+test_assert(__LINE__, strpos($login_html, "onclick='chtodo") !== FALSE, 'commentプラグイン: ログイン時はtodo操作を表示');
+$_POST = [
+    'edit_token' => kona3_getEditToken('edit_token'),
+    'bbs_id' => $bbs_id,
+    'body' => 'login comment',
+];
+kona3plugins_comment_action_write('CommentTest');
+$row = $pdo->query("SELECT * FROM comment_list WHERE body='login comment'")->fetch();
+test_assert(__LINE__, $row !== FALSE, 'commentプラグイン: ログイン時はname/password省略で投稿できる');
+test_eq(__LINE__, $row['name'], 'Login User', 'commentプラグイン: ログイン投稿はユーザー名を保存');
+test_eq(__LINE__, intval($row['user_id']), 1001, 'commentプラグイン: ログイン投稿はuser_idを保存');
+test_assert(__LINE__, kona3plugins_comment_canDeleteAsLoginUser($row), 'commentプラグイン: ログインユーザーは自分のコメントを削除できる');
+$del_form = kona3plugins_comment_renderDeleteForm($row['comment_id'], kona3_getEditToken('edit_token'), FALSE);
+test_assert(__LINE__, strpos($del_form, lang('Really?')) !== FALSE, 'commentプラグイン: 削除前に確認を表示');
+test_assert(__LINE__, strpos($del_form, "type='password'") === FALSE, 'commentプラグイン: 自分のコメント削除確認ではパスワード入力を省略');
+$_POST = [
+    'edit_token' => kona3_getEditToken('edit_token'),
+    'id' => $row['comment_id'],
+];
+$_REQUEST = ['m' => 'del2', 'id' => $row['comment_id']];
+kona3plugins_comment_action();
+$deleted_row = kona3plugins_comment_getComment($pdo, $row['comment_id']);
+test_assert(__LINE__, $deleted_row === FALSE, 'commentプラグイン: 自分のコメントは確認後にパスワードなしで削除');
+
+$stmt->execute([$bbs_id, 'Other User', 'other comment', '', 100, 100]);
+$other_id = $pdo->lastInsertId();
+$pdo->prepare('UPDATE comment_list SET user_id=? WHERE comment_id=?')->execute([2002, $other_id]);
+$other_row = kona3plugins_comment_getComment($pdo, $other_id);
+test_assert(__LINE__, !kona3plugins_comment_canDeleteAsLoginUser($other_row), 'commentプラグイン: 他人のコメントは一般ログインユーザーでは削除不可');
+$_REQUEST = [];
+$_POST = [];
+kona3logout();
+
+kona3login('Admin User', 'admin@example.com', 'admin', 1);
+test_assert(__LINE__, kona3plugins_comment_canDeleteAsLoginUser($other_row), 'commentプラグイン: 管理ユーザーは全コメントを削除できる');
+$admin_del_form = kona3plugins_comment_renderDeleteForm($other_id, kona3_getEditToken('edit_token'), FALSE);
+test_assert(__LINE__, strpos($admin_del_form, "type='password'") === FALSE, 'commentプラグイン: 管理ユーザーの削除確認ではパスワード入力を省略');
+$_POST = [
+    'edit_token' => kona3_getEditToken('edit_token'),
+    'id' => $other_id,
+];
+$_REQUEST = ['m' => 'del2', 'id' => $other_id];
+kona3plugins_comment_action();
+$admin_deleted_row = kona3plugins_comment_getComment($pdo, $other_id);
+test_assert(__LINE__, $admin_deleted_row === FALSE, 'commentプラグイン: 管理ユーザーは確認後にパスワードなしで削除');
+$_REQUEST = [];
+$_POST = [];
+kona3logout();
+
+$guest_del_form = kona3plugins_comment_renderDeleteForm(1, kona3_getEditToken('edit_token'), TRUE);
+test_assert(__LINE__, strpos($guest_del_form, "type='password'") !== FALSE, 'commentプラグイン: 未ログイン削除確認ではパスワード入力を表示');
+
+$guest_all_html = kona3plugins_comment_execute(['type=all']);
+test_assert(__LINE__, strpos($guest_all_html, lang('Please login.')) !== FALSE, 'commentプラグイン: 未ログイン時は全コメント一覧を表示しない');
+test_assert(__LINE__, strpos($guest_all_html, 'Comments (type=all)') === FALSE, 'commentプラグイン: 未ログイン時は全コメント一覧本体を隠す');
+
+$login_only_html = kona3plugins_comment_execute(['loginOnly']);
+test_assert(__LINE__, strpos($login_only_html, lang('Please login.')) !== FALSE, 'commentプラグイン: loginOnly未ログイン時はログイン案内を表示');
+test_assert(__LINE__, strpos($login_only_html, 'href="index.php?CommentTest&amp;login"') !== FALSE, 'commentプラグイン: loginOnly未ログイン時はログインリンクを表示');
+test_assert(__LINE__, strpos($login_only_html, 'id="edit_token"') !== FALSE, 'commentプラグイン: loginOnly未ログイン時もtodo用edit_tokenを埋め込む');
+test_assert(__LINE__, strpos($login_only_html, 'id="kona3comment_body"') === FALSE, 'commentプラグイン: loginOnly未ログイン時は投稿フォームを隠す');
+$login_only_eq_html = kona3plugins_comment_execute(['loginOnly=1']);
+test_assert(__LINE__, strpos($login_only_eq_html, lang('Please login.')) !== FALSE, 'commentプラグイン: loginOnly=1未ログイン時はログイン案内を表示');
+
+$kona3_comment_todo_script = null;
+$script1 = _todo_script();
+$script2 = _todo_script();
+test_assert(__LINE__, strpos($script1, 'function chtodo') !== FALSE, 'commentプラグイン: todoスクリプトを生成');
+test_assert(__LINE__, strpos($script1, 'event.preventDefault();') !== FALSE, 'commentプラグイン: todoリンクの既定動作を止める');
+test_assert(__LINE__, strpos($script1, 'var comment_api = "index.php?CommentTest\u0026plugin\u0026name=comment";') !== FALSE, 'commentプラグイン: todo API URLをJavaScript文字列として生成');
+test_assert(__LINE__, strpos($script1, '&amp;plugin') === FALSE, 'commentプラグイン: todo API URLをHTMLエスケープしない');
+test_eq(__LINE__, $script2, '', 'commentプラグイン: todoスクリプトは重複出力しない');
+
+$kona3_comment_todo_script = null;
+$admin_html = _renderCommentAdminPage($pdo, 'all');
+test_assert(__LINE__, strpos($admin_html, 'Comments (type=all)') !== FALSE, 'commentプラグイン: 全コメント管理ページのタイトルを表示');
+test_assert(__LINE__, strpos($admin_html, 'name=comment&amp;m=list&amp;type=all') !== FALSE, 'commentプラグイン: 全コメント管理ページにallリンクを表示');
+test_assert(__LINE__, strpos($admin_html, 'name=comment&amp;m=list&amp;type=todo') !== FALSE, 'commentプラグイン: 全コメント管理ページにtodoリンクを表示');
+test_assert(__LINE__, strpos($admin_html, 'name="edit_token"') !== FALSE || strpos($admin_html, "name='edit_token'") !== FALSE, 'commentプラグイン: 全コメント管理ページにedit_tokenを埋め込む');
+test_assert(__LINE__, strpos($admin_html, 'Alice &amp; Bob') !== FALSE, 'commentプラグイン: 全コメント管理ページにコメントを表示');
+test_assert(__LINE__, strpos($admin_html, "href='index.php?CommentTest&amp;show#CommentBox'") !== FALSE, 'commentプラグイン: 全コメント管理ページのページリンクURLをHTMLエスケープ');
+test_assert(__LINE__, strpos($admin_html, "href='index.php?CommentTest&show#CommentBox'") === FALSE, 'commentプラグイン: 全コメント管理ページのページリンクURLに未エスケープの&を出力しない');
+
+if ($original_db_info === null) {
+    unset($FW_DB_INFO['main']);
+} else {
+    $FW_DB_INFO['main'] = $original_db_info;
+}
+@unlink($tmp_db);
+@unlink($tmp_sql);


### PR DESCRIPTION
## Summary
- Fix comment plugin CSRF token handling so posting and todo toggles use the submitted `edit_token` correctly.
- Add a comment list management view, `loginOnly` mode, logged-in user posting without name/password fields, and ownership-aware deletion.
- Add delete confirmation before removal, preserve password-based deletion for guest comments, allow owners/admins to delete without passwords, and document the plugin behavior in the source comment.

## Root Cause
- The comment form submitted `edit_token`, but some action paths validated the default token key.
- The todo Ajax URL was HTML-escaped inside JavaScript, causing normal HTML pages to be returned instead of JSON.
- Logged-in comments did not persist ownership metadata, so the plugin could not distinguish self-deletion from another user's comment.

## Validation
- `php -l kona3engine/plugins/comment.inc.php`
- `php -l kona3engine/tests/comment.test.php`
- `php kona3engine/tests/comment.test.php`
- `just test` (`742/742`)