### PR TITLE
fix: improve .memo text readability in dark mode (#197)

### DIFF
--- a/kona3engine/resource/darkmode.css
+++ b/kona3engine/resource/darkmode.css
@@ -405,4 +405,9 @@ body.dark-theme .kona3-tags-list a:hover {
   background-color: #31363d !important;
 }
 
+body.dark-theme .memo {
+  color: #aaa !important;
+}
+
+
 

--- a/kona3engine/tests/darkmode.test.php
+++ b/kona3engine/tests/darkmode.test.php
@@ -16,6 +16,7 @@ test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikimessage h2') !=
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikimessage h3') !== false, "darkmode.css defines #wikimessage h3 dark mode overrides");
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikifooter') !== false, "darkmode.css defines #wikifooter dark mode overrides");
 test_assert(__LINE__, strpos($css_content, 'body.dark-theme #wikifooter a') !== false, "darkmode.css defines #wikifooter a dark mode overrides");
+test_assert(__LINE__, strpos($css_content, 'body.dark-theme .memo') !== false, "darkmode.css defines .memo dark mode overrides");
 
 
 // 2. Check if parts_header.html contains toggle button and inline JS to restore preference


### PR DESCRIPTION
1. ダークモード用CSSの修正
  darkmode.css に、 .memo  クラスの文字色をダークモード向けに視認性の高い明るいグレー ( #aaa )
  に上書きするスタイルを追加しました。
    body.dark-theme .memo {
      color: #aaa !important;
    }
  これにより、リファレンス画像等でキャプションとして使われる  .memo
  要素が、ダークモード（暗い背景）下でも重なって見づらくなる現象を解決しました。
  2. ユニットテストの追加
  darkmode.test.php に、 darkmode.css  内に上記  .memo  に関する定義が存在することを検証するアサーションを追加しました。
