### PR TITLE
[codex] Adjust CSS spacing for issue #197

### DIFF
--- a/kona3engine/resource/kona3def.css
+++ b/kona3engine/resource/kona3def.css
@@ -54,7 +54,7 @@
   border-left: 5px solid #3b82f6;
   background-color: #f8fafc;
   color: #1e293b;
-  font-size: 1.3em;
+  font-size: 1.2em;
   font-weight: 700;
   margin: 1.8em 0 1em;
   padding: 0.5em 0.8em;
@@ -351,10 +351,10 @@
 #kona3_menubar ul li a
 {
   display:block;
-  padding: 3px 8px;
+  padding: 2px 6px;
   color: #0366d6;
   text-decoration: none;
-  font-size: 0.95em;
+  font-size: 0.9em;
   border-radius: 4px;
   transition: background-color 0.2s, color 0.2s;
 }
@@ -384,7 +384,7 @@
     border-left: 1px solid #e2e8f0;
     margin-top: 0;
     padding-top: 0;
-    padding-left: 1.5em;
+    padding-left: 1em;
     box-sizing: border-box;
   }
 }

--- a/skin/aqua/kona3.css
+++ b/skin/aqua/kona3.css
@@ -77,7 +77,7 @@ body {
   border-left: 5px solid #00bcd4;
   background: linear-gradient(to right, #f1fbfd 0%, transparent 100%);
   color: #00838f;
-  font-size: 1.3em;
+  font-size: 1.2em;
   font-weight: 700;
   margin: 1.8em 0 1em;
   padding: 0.6em 0.8em;

--- a/skin/nako3/kona3.css
+++ b/skin/nako3/kona3.css
@@ -24,7 +24,7 @@
 	border-left: 5px solid #ff8080;
 	background-color: #fffcfc;
 	color: #503020;
-	font-size: 1.3em;
+	font-size: 1.2em;
 	font-weight: 700;
 	margin: 1.8em 0 1em;
 	padding: 0.5em 0.8em;


### PR DESCRIPTION
## Summary
- Reduce `#kona3_main h2` heading size from `1.3em` to `1.2em` in the default CSS and skin overrides.
- Tighten `#kona3_menubar` link padding, font size, and desktop left padding so more text fits in the menu area.

## Related Issue
- Closes #197

## Validation
- `just test` passed: `753/753`