### PR TITLE
[codex] Make editor shortcuts configurable

### DIFF
--- a/kona3engine/action/edit.inc.php
+++ b/kona3engine/action/edit.inc.php
@@ -154,6 +154,8 @@ function kona3_action_edit()
         "ai_provider" => $ai_provider,
         "ai_edit_template_url" => $ai_edit_template_url,
         "ai_edit_conf_url" => $ai_edit_conf_url,
+        "editor_shortcut_temp_save" => kona3getConf('editor_shortcut_temp_save', 'Ctrl+S'),
+        "editor_shortcut_new" => kona3getConf('editor_shortcut_new', 'Ctrl+Alt+N'),
         "ai_shortcut_complete" => kona3getConf('ai_shortcut_complete', 'Ctrl+Shift+H'),
         "ai_shortcut_spellcheck" => kona3getConf('ai_shortcut_spellcheck', 'Ctrl+Shift+J'),
         "ai_shortcut_user_prompt1" => kona3getConf('ai_shortcut_user_prompt1', 'Ctrl+Alt+1'),

--- a/kona3engine/kona3conf.inc.php
+++ b/kona3engine/kona3conf.inc.php
@@ -103,6 +103,10 @@ function kona3conf_getConfigItems()
             'max_search' => ['label' => 'Max Search', 'default' => 10, 'type' => 'number'],
             'max_search_level' => ['label' => 'Max Search Level', 'default' => 2, 'type' => 'number'],
         ],
+        'Editor' => [
+            'editor_shortcut_temp_save' => ['label' => 'ショートカットキー > 一時保存', 'default' => 'Ctrl+S', 'type' => 'string'],
+            'editor_shortcut_new' => ['label' => 'ショートカットキー > 📖 新規', 'default' => 'Ctrl+Alt+N', 'type' => 'string'],
+        ],
         'Uploader' => [
             'image_pattern' => ['label' => 'Image Pattern', 'default' => '(png|jpg|jpeg|gif|bmp|ico|svg|webp)', 'type' => 'string'],
             'allow_upload' => ['label' => 'Allow Upload', 'default' => FALSE, 'type' => 'bool'],

--- a/kona3engine/resource/edit.js
+++ b/kona3engine/resource/edit.js
@@ -74,9 +74,9 @@ function edit_init() {
       e.preventDefault()
     }
     if (matchesShortcut(e, getShortcutValue('editor_shortcut_new'))) {
-      $url = document.getElementById('new_btn_url').href
-      console.log('open new page:', $url)
-      window.open($url)
+      const url = document.getElementById('new_btn_url').href
+      console.log('open new page:', url)
+      window.open(url)
       e.preventDefault()
     }
     if (matchesShortcut(e, getShortcutValue('ai_shortcut_complete'))) {

--- a/kona3engine/resource/edit.js
+++ b/kona3engine/resource/edit.js
@@ -67,15 +67,13 @@ function edit_init() {
 
   // shortcut
   qq(window).keydown(function (e) {
-    // shortcut Ctrl+S
-    if ((e.metaKey || e.ctrlKey) && e.keyCode == 83) {
+    if (matchesShortcut(e, getShortcutValue('editor_shortcut_temp_save'))) {
       if (isChanged) {
-        ajaxSave('Shortcut:Ctrl+S')
+        ajaxSave('Shortcut:' + getShortcutValue('editor_shortcut_temp_save'))
       }
       e.preventDefault()
     }
-    // shortcut Ctrl+Alt+N
-    if ((e.metaKey || e.ctrlKey) && e.altKey && e.keyCode == 78) {
+    if (matchesShortcut(e, getShortcutValue('editor_shortcut_new'))) {
       $url = document.getElementById('new_btn_url').href
       console.log('open new page:', $url)
       window.open($url)

--- a/kona3engine/template/edit.html
+++ b/kona3engine/template/edit.html
@@ -11,6 +11,8 @@
       <input type="hidden" id="edit_token" name="edit_token" value="{{$edit_token}}">
       <input type="hidden" id="edit_ext" name="edit_ext" value="{{$edit_ext}}">
       <input type="hidden" id="tags" name="tags" value="{{ $tags }}">
+      <input type="hidden" id="editor_shortcut_temp_save" value="{{ $editor_shortcut_temp_save }}">
+      <input type="hidden" id="editor_shortcut_new" value="{{ $editor_shortcut_new }}">
       <input type="hidden" id="ai_shortcut_complete" value="{{ $ai_shortcut_complete }}">
       <input type="hidden" id="ai_shortcut_spellcheck" value="{{ $ai_shortcut_spellcheck }}">
       <input type="hidden" id="ai_shortcut_user_prompt1" value="{{ $ai_shortcut_user_prompt1 }}">
@@ -67,8 +69,8 @@
           </ul>
           <h3>Shortcut:</h3>
           <ul>
-            <li>{{'Save temp' | lang}} ... Ctrl+S</li>
-            <li><a id="new_btn_url" href="{{$new_btn_url}}" target="_new">{{'New' | lang}}</a> ... Ctrl+Alt+N</li>
+            <li>{{'Save temp' | lang}} ... {{$editor_shortcut_temp_save}}</li>
+            <li><a id="new_btn_url" href="{{$new_btn_url}}" target="_new">{{'New' | lang}}</a> ... {{$editor_shortcut_new}}</li>
           </ul>
         </div>
       </div>

--- a/kona3engine/tests/edit_ai.test.php
+++ b/kona3engine/tests/edit_ai.test.php
@@ -58,6 +58,10 @@ test_assert(__LINE__, strpos($edit_template, '{{\'Edit AI Config\' | lang}}') !=
 test_assert(__LINE__, strpos($edit_template, 'https://kujirahand.com/konawiki3/index.php?AI') !== FALSE, "AI編集画面: AIヘルプリンクが表示される");
 test_assert(__LINE__, strpos($edit_template, 'target="_blank"') !== FALSE, "AI編集画面: AIヘルプリンクは新規ウィンドウで開く");
 test_assert(__LINE__, strpos($edit_template, '>？</a>') !== FALSE, "AI編集画面: AIヘルプリンクは疑問符で表示される");
+test_assert(__LINE__, strpos($edit_template, 'id="editor_shortcut_temp_save"') !== FALSE, "編集画面: 一時保存ショートカット設定をJSへ渡す");
+test_assert(__LINE__, strpos($edit_template, 'id="editor_shortcut_new"') !== FALSE, "編集画面: 新規ショートカット設定をJSへ渡す");
+test_assert(__LINE__, strpos($edit_template, '{{$editor_shortcut_temp_save}}') !== FALSE, "編集画面: 一時保存ショートカットをヘルプに表示する");
+test_assert(__LINE__, strpos($edit_template, '{{$editor_shortcut_new}}') !== FALSE, "編集画面: 新規ショートカットをヘルプに表示する");
 test_assert(__LINE__, strpos($edit_template, 'id="ai_shortcut_user_prompt1"') !== FALSE, "AI編集画面: USER_PROMPT1ショートカット設定をJSへ渡す");
 test_assert(__LINE__, strpos($edit_template, 'id="ai_shortcut_user_prompt2"') !== FALSE, "AI編集画面: USER_PROMPT2ショートカット設定をJSへ渡す");
 test_assert(__LINE__, strpos($edit_template, 'id="ai_model"') === FALSE, "AI編集画面: モデル入力UIは表示しない");
@@ -75,6 +79,8 @@ test_assert(__LINE__, strpos($edit_js, 'function aiNormalizeJsonRow') !== FALSE,
 test_assert(__LINE__, strpos($edit_js, "'ErrorLocation'") !== FALSE, "AI結果表示: ErrorLocationキーをngとして扱う");
 test_assert(__LINE__, strpos($edit_js, "'Correction'") !== FALSE, "AI結果表示: Correctionキーをokとして扱う");
 test_assert(__LINE__, strpos($edit_js, "'Reason'") !== FALSE, "AI結果表示: Reasonキーをdescとして扱う");
+test_assert(__LINE__, strpos($edit_js, "getShortcutValue('editor_shortcut_temp_save')") !== FALSE, "編集ショートカット: 一時保存は設定値を使う");
+test_assert(__LINE__, strpos($edit_js, "getShortcutValue('editor_shortcut_new')") !== FALSE, "編集ショートカット: 新規は設定値を使う");
 test_assert(__LINE__, strpos($edit_js, "Boolean(e.altKey) !== wantsAlt") !== FALSE, "AIショートカット: 余分なAltキーを許可しない");
 test_assert(__LINE__, strpos($edit_js, "Boolean(e.shiftKey) !== wantsShift") !== FALSE, "AIショートカット: 余分なShiftキーを許可しない");
 test_assert(__LINE__, strpos($edit_js, "if (wantsCtrl && wantsMeta)") !== FALSE, "AIショートカット: CtrlとMetaの同時指定は無効にする");

--- a/kona3engine/tests/kona3conf.test.php
+++ b/kona3engine/tests/kona3conf.test.php
@@ -210,6 +210,9 @@ test_eq(__LINE__, $flat_items['openai_api_basic_instruction']['default'], 'You a
 test_eq(__LINE__, $flat_items['openai_provider']['default'], 'none', "設定項目定義: AIプロバイダーデフォルト値");
 test_eq(__LINE__, $flat_items['openrouter_apikey']['default'], '', "設定項目定義: OpenRouter APIキーデフォルト値");
 test_eq(__LINE__, $flat_items['openrouter_model']['default'], '', "設定項目定義: OpenRouter モデルデフォルト値");
+test_assert(__LINE__, isset($config_items['Editor']['editor_shortcut_temp_save']), "設定項目定義: Editorに一時保存ショートカットがある");
+test_eq(__LINE__, $flat_items['editor_shortcut_temp_save']['default'], 'Ctrl+S', "設定項目定義: 一時保存ショートカット");
+test_eq(__LINE__, $flat_items['editor_shortcut_new']['default'], 'Ctrl+Alt+N', "設定項目定義: 新規ショートカット");
 test_eq(__LINE__, $flat_items['ai_shortcut_complete']['default'], 'Ctrl+Shift+H', "設定項目定義: AI文章補完ショートカット");
 test_eq(__LINE__, $flat_items['ai_shortcut_spellcheck']['default'], 'Ctrl+Shift+J', "設定項目定義: AI誤字脱字修正ショートカット");
 test_eq(__LINE__, $flat_items['ai_shortcut_user_prompt1']['default'], 'Ctrl+Alt+1', "設定項目定義: AI USER_PROMPT1ショートカット");


### PR DESCRIPTION
## Summary
- Add an `Editor` settings section for edit-page shortcuts.
- Make temporary save and new-page shortcuts read from configuration instead of fixed JavaScript checks.
- Show the configured shortcut values in the edit-page help and add regression coverage.

## Issue
Fixes #200

## Tests
- `php kona3engine/tests/kona3conf.test.php`
- `php kona3engine/tests/edit_ai.test.php`
- `just test`