### PR TITLE
Implement counter history feature for logged in users (fixes #217)

### DIFF
--- a/kona3engine/action/counter.inc.php
+++ b/kona3engine/action/counter.inc.php
@@ -1,0 +1,48 @@
+<?php
+
+require_once dirname(__DIR__) . '/kona3lib.inc.php';
+
+function kona3_action_counter()
+{
+    global $kona3conf;
+    
+    // ログインチェック
+    if (!kona3isLogin()) {
+        kona3error(
+            lang('Login Required'),
+            lang('You must login to view counter history.')
+        );
+        exit;
+    }
+
+    $page = $kona3conf['page'];
+    $page_id = kona3db_getPageId($page, FALSE);
+    
+    if ($page_id == 0) {
+        kona3error(
+            lang('Error'),
+            lang('Page not found.')
+        );
+        exit;
+    }
+
+    // 累計アクセス数
+    $total = 0;
+    $r = subdb_get1("SELECT * FROM counter WHERE page_id=?", [$page_id]);
+    if ($r) {
+        $total = $r['value'];
+    }
+
+    // 月ごとのアクセス数
+    $list = subdb_get(
+        "SELECT * FROM counter_month WHERE page_id=? ORDER BY year DESC, month DESC",
+        [$page_id]
+    );
+
+    // テンプレートの呼び出し
+    kona3template('counter.html', [
+        'page' => $page,
+        'total' => $total,
+        'list' => $list,
+    ]);
+}

--- a/kona3engine/action/counter.inc.php
+++ b/kona3engine/action/counter.inc.php
@@ -15,6 +15,15 @@ function kona3_action_counter()
         exit;
     }
 
+    // テーブル存在チェック
+    if (!db_table_exists('counter', 'subdb') || !db_table_exists('counter_month', 'subdb')) {
+        kona3error(
+            lang('Error'),
+            lang('Counter table not found.')
+        );
+        exit;
+    }
+
     $page = $kona3conf['page'];
     $page_id = kona3db_getPageId($page, FALSE);
     

--- a/kona3engine/lang/en.inc.php
+++ b/kona3engine/lang/en.inc.php
@@ -56,4 +56,5 @@ $lang_data = [
     'Month' => 'Month',
     'Login Required' => 'Login Required',
     'You must login to view counter history.' => 'You must login to view counter history.',
+    'Counter table not found.' => 'Counter table not found.',
 ];

--- a/kona3engine/lang/en.inc.php
+++ b/kona3engine/lang/en.inc.php
@@ -47,4 +47,13 @@ $lang_data = [
     'Increase Line Height' => '↕ Increase Line Height',
     'Decrease Line Height' => '↕ Decrease Line Height',
     'Reset Font & Line Height' => '⊚ Reset Font & Line Height',
+    'Access Log' => 'Access Log',
+    'Monthly Access Log' => 'Monthly Access Log',
+    'Access Count' => 'Access Count',
+    'Last Access' => 'Last Access',
+    'Total' => 'Total',
+    'Year' => 'Year',
+    'Month' => 'Month',
+    'Login Required' => 'Login Required',
+    'You must login to view counter history.' => 'You must login to view counter history.',
 ];

--- a/kona3engine/lang/ja.inc.php
+++ b/kona3engine/lang/ja.inc.php
@@ -145,4 +145,13 @@ $lang_data = [
     'Increase Line Height' => '↕ 行間を広く',
     'Decrease Line Height' => '↕ 行間を狭く',
     'Reset Font & Line Height' => '⊚ 文字と行間をリセット',
+    'Access Log' => 'アクセスログ',
+    'Monthly Access Log' => '月間アクセスログ',
+    'Access Count' => 'アクセス数',
+    'Last Access' => '最終アクセス',
+    'Total' => '累計',
+    'Year' => '年',
+    'Month' => '月',
+    'Login Required' => 'ログインが必要です',
+    'You must login to view counter history.' => 'カウンター履歴を表示するにはログインする必要があります。',
 ];

--- a/kona3engine/lang/ja.inc.php
+++ b/kona3engine/lang/ja.inc.php
@@ -154,4 +154,5 @@ $lang_data = [
     'Month' => '月',
     'Login Required' => 'ログインが必要です',
     'You must login to view counter history.' => 'カウンター履歴を表示するにはログインする必要があります。',
+    'Counter table not found.' => 'カウンターテーブルが見つかりません。',
 ];

--- a/kona3engine/plugins/counter.inc.php
+++ b/kona3engine/plugins/counter.inc.php
@@ -74,9 +74,13 @@ function kona3plugins_counter_execute($args)
     );
     //
     $m_this = lang('Monthly');
+    $html = "$value" . "<span class='coutner_month'>({$m_this}{$mvalue})</span>";
+    if (kona3isLogin()) {
+        $url = kona3getPageURL($page, 'counter');
+        $html = "<a href='{$url}'>{$html}</a>";
+    }
     return
         "<div class='counter'>" .
-        "$value" .
-        "<span class='coutner_month'>({$m_this}{$mvalue})</span>" .
+        $html .
         "</div>";
 }

--- a/kona3engine/template/counter.html
+++ b/kona3engine/template/counter.html
@@ -1,0 +1,36 @@
+{{ include parts_header.html }}
+
+<div id="wikimessage"><div class="box">
+  <div class="box_border">
+    <h2>{{$page}} - {{'Access Log'|lang}}</h2>
+    <p>{{'Total'|lang}}: <strong>{{$total}}</strong></p>
+  </div>
+
+  <div class="box_border">
+    <h3>{{'Monthly Access Log'|lang}}</h3>
+    {{ if count($list) == 0 }}
+      <p>No log data.</p>
+    {{ else }}
+      <table class="pure-table pure-table-bordered" style="width:100%;">
+        <thead>
+          <tr>
+            <th>{{'Year'|lang}} / {{'Month'|lang}}</th>
+            <th>{{'Access Count'|lang}}</th>
+            <th>{{'Last Access'|lang}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {{ for $list as $v }}
+          <tr>
+            <td>{{$v.year}} / {{$v.month}}</td>
+            <td>{{$v.value}}</td>
+            <td>{{$v.mtime | datetime}}</td>
+          </tr>
+          {{ endfor }}
+        </tbody>
+      </table>
+    {{ endif }}
+  </div>
+</div></div>
+
+{{ include parts_footer.html }}

--- a/kona3engine/tests/counter.test.php
+++ b/kona3engine/tests/counter.test.php
@@ -28,7 +28,7 @@ test_eq(__LINE__, kona3isLogin(), TRUE, "Logged in check");
 // counterプラグインを実行して出力を確認
 $html_logged_in = kona3plugins_counter_execute([]);
 test_assert(__LINE__, strpos($html_logged_in, 'href=') !== FALSE, "Logged in should have links in counter");
-test_assert(__LINE__, strpos($html_logged_in, 'counter') !== FALSE, "Logged in link should point to counter action");
+test_assert(__LINE__, preg_match('/href=[\'"][^\'"]*counter/', $html_logged_in) === 1, "Logged in link should point to counter action");
 
 // 3. データベースに正しくカウントが保存されているか確認
 $page_id = kona3db_getPageId($test_page, FALSE);
@@ -50,6 +50,5 @@ $kona3conf['page'] = $original_page;
 if (file_exists($filepath)) {
     unlink($filepath);
 }
-db_exec("DELETE FROM users WHERE user_id=?", [99999]);
 subdb_exec("DELETE FROM counter WHERE page_id=?", [$page_id]);
 subdb_exec("DELETE FROM counter_month WHERE page_id=?", [$page_id]);

--- a/kona3engine/tests/counter.test.php
+++ b/kona3engine/tests/counter.test.php
@@ -1,0 +1,55 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+require_once dirname(__DIR__) . '/plugins/counter.inc.php';
+
+// テスト用のダミーのPage名
+global $kona3conf;
+$original_page = isset($kona3conf['page']) ? $kona3conf['page'] : 'FrontPage';
+
+$test_page = "TestCounterPage_" . time();
+$kona3conf['page'] = $test_page;
+
+// ダミーファイルを作成
+$filepath = kona3getWikiFile($test_page);
+kona3lock_save($filepath, "test counter");
+
+// 1. ログインしていない状態でのテスト
+unset($_SESSION[KONA3_SESSKEY_LOGIN]);
+test_eq(__LINE__, kona3isLogin(), FALSE, "Not logged in check");
+
+// counterプラグインを実行して出力を確認
+$html_not_logged_in = kona3plugins_counter_execute([]);
+test_assert(__LINE__, strpos($html_not_logged_in, 'href=') === FALSE, "Not logged in should NOT have links in counter");
+
+// 2. ログインした状態でのテスト
+kona3login('test-counter-user', 'test-counter@example.com', 'normal', 99999);
+test_eq(__LINE__, kona3isLogin(), TRUE, "Logged in check");
+
+// counterプラグインを実行して出力を確認
+$html_logged_in = kona3plugins_counter_execute([]);
+test_assert(__LINE__, strpos($html_logged_in, 'href=') !== FALSE, "Logged in should have links in counter");
+test_assert(__LINE__, strpos($html_logged_in, 'counter') !== FALSE, "Logged in link should point to counter action");
+
+// 3. データベースに正しくカウントが保存されているか確認
+$page_id = kona3db_getPageId($test_page, FALSE);
+test_assert(__LINE__, $page_id > 0, "Page ID should be created");
+
+$total_r = subdb_get1("SELECT * FROM counter WHERE page_id=?", [$page_id]);
+test_assert(__LINE__, isset($total_r['value']), "Counter record should exist");
+test_eq(__LINE__, $total_r['value'], 2, "Counter value should be 2 (run twice)");
+
+$year  = intval(date('Y'));
+$month = intval(date('n'));
+$month_r = subdb_get1("SELECT * FROM counter_month WHERE page_id=? AND year=? AND month=?", [$page_id, $year, $month]);
+test_assert(__LINE__, isset($month_r['value']), "Monthly counter record should exist");
+test_eq(__LINE__, $month_r['value'], 2, "Monthly counter value should be 2");
+
+// クリーンアップ
+unset($_SESSION[KONA3_SESSKEY_LOGIN]);
+$kona3conf['page'] = $original_page;
+if (file_exists($filepath)) {
+    unlink($filepath);
+}
+db_exec("DELETE FROM users WHERE user_id=?", [99999]);
+subdb_exec("DELETE FROM counter WHERE page_id=?", [$page_id]);
+subdb_exec("DELETE FROM counter_month WHERE page_id=?", [$page_id]);


### PR DESCRIPTION
ログインユーザーがcounterをクリックしたときに、そのページのこれまでのアクセス数（月ごとのアクセス数など）を表示するアクション・テンプレートを実装しました。

Fixes #217