### PR TITLE
Fix popular plugin and restore page_id on migration/lookup (#218)

### DIFF
--- a/kona3engine/action/versionup.inc.php
+++ b/kona3engine/action/versionup.inc.php
@@ -82,17 +82,23 @@ function kona3_action_versionup() {
  */
 function kona3_ver33to34() {
     $json_path = KONA3_PAGE_ID_JSON;
-    if (!file_exists($json_path)) {
+    $bak_path = $json_path . '.bak';
+    $path = $json_path;
+    if (!file_exists($path)) {
+        $path = $bak_path;
+    }
+    if (!file_exists($path)) {
         return FALSE;
     }
     
-    $jsonData = kona3lock_load($json_path);
+    $jsonData = kona3lock_load($path);
     $legacy_page_ids = json_decode($jsonData, TRUE);
     if (!is_array($legacy_page_ids) || empty($legacy_page_ids)) {
         return FALSE;
     }
     
     $created = FALSE;
+    $time = time();
     foreach ($legacy_page_ids as $name => $id) {
         // ページIDのバリデーション（安全なファイル名とするため、英数字、ハイフン、アンダースコアのみ許容）
         if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $id)) {
@@ -101,24 +107,33 @@ function kona3_ver33to34() {
         
         $filepath = KONA3_DIR_DATA . "/{$id}.md";
         // 既存のファイルがあるときは、上書きしない
-        if (file_exists($filepath)) {
-            continue;
+        if (!file_exists($filepath)) {
+            // エイリアスファイルを作成
+            $content = "!!alias({$name})";
+            if (kona3lock_save($filepath, $content)) {
+                $created = TRUE;
+            }
         }
         
-        // エイリアスファイルを作成
-        $content = "!!alias({$name})";
-        if (kona3lock_save($filepath, $content)) {
+        // 復元処理
+        $r = db_get1("SELECT page_id FROM pages WHERE page_id=?", [intval($id)]);
+        if (!$r) {
+            db_exec(
+                "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
+                [intval($id), $name, $time, 0]
+            );
             $created = TRUE;
         }
     }
     
     // 最後に、.json を .json.bak にリネーム
-    $bak_path = $json_path . '.bak';
-    if (@rename($json_path, $bak_path) === FALSE) {
-        if (@copy($json_path, $bak_path) === FALSE) {
-            return FALSE;
+    if (file_exists($json_path)) {
+        if (@rename($json_path, $bak_path) === FALSE) {
+            if (@copy($json_path, $bak_path) === FALSE) {
+                return FALSE;
+            }
+            @unlink($json_path);
         }
-        @unlink($json_path);
     }
     
     return $created;

--- a/kona3engine/action/versionup.inc.php
+++ b/kona3engine/action/versionup.inc.php
@@ -100,8 +100,8 @@ function kona3_ver33to34() {
     $created = FALSE;
     $time = time();
     foreach ($legacy_page_ids as $name => $id) {
-        // ページIDのバリデーション（安全なファイル名とするため、英数字、ハイフン、アンダースコアのみ許容）
-        if (!preg_match('/^[a-zA-Z0-9_\-]+$/', $id)) {
+        // ページIDのバリデーション（数値のみで1以上であることを確認）
+        if (!preg_match('/^[1-9][0-9]*$/', $id)) {
             continue;
         }
         

--- a/kona3engine/kona3db.inc.php
+++ b/kona3engine/kona3db.inc.php
@@ -14,17 +14,19 @@ function kona3db_getPageId($page, $canCreate = FALSE)
     $legacy_page_ids = kona3db_loadLegacyPageIds();
     if (isset($legacy_page_ids[$page])) {
         $legacy_page_id = intval($legacy_page_ids[$page]);
-        $time = time();
-        db_exec(
-            "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
-            [$legacy_page_id, $page, $time, 0]
-        );
-        $r = db_get1(
-            "SELECT page_id FROM pages WHERE name=?",
-            [$page]
-        );
-        if ($r && isset($r['page_id'])) {
-            return intval($r['page_id']);
+        if ($legacy_page_id > 0) {
+            $time = time();
+            db_exec(
+                "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
+                [$legacy_page_id, $page, $time, 0]
+            );
+            $r = db_get1(
+                "SELECT page_id FROM pages WHERE name=?",
+                [$page]
+            );
+            if ($r && isset($r['page_id'])) {
+                return intval($r['page_id']);
+            }
         }
     }
     if (!$canCreate) {
@@ -61,12 +63,14 @@ function kona3db_getPageNameById($page_id, $default = '')
         if (intval($id) !== intval($page_id)) {
             continue;
         }
-        $time = time();
-        db_exec(
-            "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
-            [intval($page_id), $name, $time, 0]
-        );
-        return $name;
+        if (intval($page_id) > 0) {
+            $time = time();
+            db_exec(
+                "INSERT OR IGNORE INTO pages (page_id, name, ctime, mtime) VALUES (?, ?, ?, ?)",
+                [intval($page_id), $name, $time, 0]
+            );
+            return $name;
+        }
     }
     return $default;
 }

--- a/kona3engine/kona3db.inc.php
+++ b/kona3engine/kona3db.inc.php
@@ -71,17 +71,24 @@ function kona3db_getPageNameById($page_id, $default = '')
     return $default;
 }
 
-function kona3db_loadLegacyPageIds()
+function kona3db_loadLegacyPageIds($force = FALSE)
 {
     static $legacy_page_ids = NULL;
+    if ($force) {
+        $legacy_page_ids = NULL;
+    }
     if ($legacy_page_ids !== NULL) {
         return $legacy_page_ids;
     }
     $legacy_page_ids = [];
-    if (!file_exists(KONA3_PAGE_ID_JSON)) {
+    $path = KONA3_PAGE_ID_JSON;
+    if (!file_exists($path)) {
+        $path = KONA3_PAGE_ID_JSON . '.bak';
+    }
+    if (!file_exists($path)) {
         return $legacy_page_ids;
     }
-    $jsonData = kona3lock_load(KONA3_PAGE_ID_JSON);
+    $jsonData = kona3lock_load($path);
     $legacy_page_ids = kona3db_decodeLegacyPageIds($jsonData);
     return $legacy_page_ids;
 }

--- a/kona3engine/plugins/popular.inc.php
+++ b/kona3engine/plugins/popular.inc.php
@@ -18,7 +18,7 @@ function kona3plugins_popular_execute($args)
     }
 
     // can i use popular?
-    if (!db_table_exists("counter")) {
+    if (!db_table_exists("counter", "subdb")) {
         return "<h3>" . lang('Popular') . "</h3><p>---</p>";
     }
 

--- a/kona3engine/tests/popular.test.php
+++ b/kona3engine/tests/popular.test.php
@@ -1,0 +1,76 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+require_once dirname(__DIR__) . '/plugins/popular.inc.php';
+
+// 1. テスト用ページの設定
+$page1 = "TestPopularPage1_" . time();
+$page2 = "TestPopularPage2_" . time();
+
+$id1 = kona3db_getPageId($page1, TRUE);
+$id2 = kona3db_getPageId($page2, TRUE);
+
+test_assert(__LINE__, $id1 > 0 && $id2 > 0, "Page IDs created successfully");
+
+// 2. カウンターを登録
+$time = time();
+subdb_exec("INSERT OR REPLACE INTO counter (page_id, value, mtime) VALUES (?, ?, ?)", [$id1, 100, $time]);
+subdb_exec("INSERT OR REPLACE INTO counter (page_id, value, mtime) VALUES (?, ?, ?)", [$id2, 200, $time]);
+
+// 3. popularプラグインの実行
+$html = kona3plugins_popular_execute([2]); // limit = 2
+test_assert(__LINE__, strpos($html, $page1) !== FALSE, "Page 1 should be in popular list");
+test_assert(__LINE__, strpos($html, $page2) !== FALSE, "Page 2 should be in popular list");
+test_assert(__LINE__, strpos($html, '(100)') !== FALSE, "Page 1 count should be displayed");
+test_assert(__LINE__, strpos($html, '(200)') !== FALSE, "Page 2 count should be displayed");
+
+// 4. レガシーJSON.bakを元にした復元テスト
+// pagesテーブルから page2 のデータを一時的に消す
+db_exec("DELETE FROM pages WHERE page_id=?", [$id2]);
+test_eq(__LINE__, kona3db_getPageNameById($id2, ''), '', "Page 2 name should not be resolved directly since it is deleted from pages table");
+
+// レガシーJSONファイルをモックして作成
+$original_json_data = null;
+$original_bak_data = null;
+$json_path = KONA3_PAGE_ID_JSON;
+$bak_path = $json_path . '.bak';
+if (file_exists($json_path)) {
+    $original_json_data = file_get_contents($json_path);
+    unlink($json_path);
+}
+if (file_exists($bak_path)) {
+    $original_bak_data = file_get_contents($bak_path);
+    unlink($bak_path);
+}
+
+// .json.bak に登録
+$dummy_legacy = [
+    $page2 => $id2
+];
+file_put_contents($bak_path, json_encode($dummy_legacy));
+
+// キャッシュをクリア
+kona3db_loadLegacyPageIds(TRUE);
+
+// 再度 popular プラグインを実行。このとき、kona3db_getPageNameById($id2) が内部で legacy json.bak を探し出し、
+// 自動的に pages テーブルにインサートしてページ名を解決するはず。
+$html2 = kona3plugins_popular_execute([2]);
+test_assert(__LINE__, strpos($html2, $page2) !== FALSE, "Page 2 should be resolved from legacy .json.bak and shown in popular list");
+test_assert(__LINE__, strpos($html2, '(200)') !== FALSE, "Page 2 count should still be shown");
+
+// pages テーブルに復元されていることを検証
+$resolved_name = db_get1("SELECT name FROM pages WHERE page_id=?", [$id2]);
+test_eq(__LINE__, $resolved_name ? $resolved_name['name'] : '', $page2, "Page 2 should be automatically restored to pages table");
+
+// 5. クリーンアップ
+subdb_exec("DELETE FROM counter WHERE page_id IN (?, ?)", [$id1, $id2]);
+db_exec("DELETE FROM pages WHERE page_id IN (?, ?)", [$id1, $id2]);
+if (file_exists($bak_path)) {
+    unlink($bak_path);
+}
+if ($original_json_data !== null) {
+    file_put_contents($json_path, $original_json_data);
+}
+if ($original_bak_data !== null) {
+    file_put_contents($bak_path, $original_bak_data);
+}
+echo "popular.test.php completed successfully\n";

--- a/kona3engine/tests/versionup.test.php
+++ b/kona3engine/tests/versionup.test.php
@@ -52,6 +52,11 @@ try {
     test_eq(__LINE__, $content2, "!!alias(TestMigrationPage2)", "Alias file 2 contents match");
     test_eq(__LINE__, $content3, "!!alias(hoge/実行権限)", "Alias file 3 contents match with Japanese page and slashes");
 
+    // 4.5. Verify db mapping
+    test_eq(__LINE__, kona3db_getPageNameById(99991), "TestMigrationPage1", "Database page name for 99991 is restored");
+    test_eq(__LINE__, kona3db_getPageNameById(99992), "TestMigrationPage2", "Database page name for 99992 is restored");
+    test_eq(__LINE__, kona3db_getPageNameById(99993), "hoge/実行権限", "Database page name for 99993 is restored");
+
     // 5. Verify JSON is renamed to JSON.bak
     test_assert(__LINE__, !file_exists($json_path), "Original JSON should be removed");
     test_assert(__LINE__, file_exists($bak_path), "Original JSON should be renamed to JSON.bak");
@@ -71,6 +76,9 @@ try {
     test_eq(__LINE__, $content1_rerun, "Existing content - do not overwrite", "Existing file should not be overwritten");
 
 } finally {
+    // DB cleanup
+    db_exec("DELETE FROM pages WHERE page_id IN (99991, 99992, 99993)");
+
     // Cleanup generated files
     if (file_exists($file1)) { unlink($file1); }
     if (file_exists($file2)) { unlink($file2); }


### PR DESCRIPTION
Fixes #218. Implements page_id restoration to pages table during versionup and page lookup, and fixes popular plugin counter table database reference.