### PR TITLE
Fix double underscore emphasis issue #229

### DIFF
--- a/kona3engine/kona3conf.inc.php
+++ b/kona3engine/kona3conf.inc.php
@@ -103,6 +103,9 @@ function kona3conf_getConfigItems()
             'max_search' => ['label' => 'Max Search', 'default' => 10, 'type' => 'number'],
             'max_search_level' => ['label' => 'Max Search Level', 'default' => 2, 'type' => 'number'],
         ],
+        'Markdown' => [
+            'md_underscore_emphasis' => ['label' => 'Markdown Underscore Emphasis', 'default' => FALSE, 'type' => 'bool'],
+        ],
         'Editor' => [
             'editor_shortcut_temp_save' => ['label' => 'ショートカットキー > 一時保存', 'default' => 'Ctrl+S', 'type' => 'string'],
             'editor_shortcut_new' => ['label' => 'ショートカットキー > 📖 新規', 'default' => 'Ctrl+Alt+N', 'type' => 'string'],

--- a/kona3engine/kona3parser_md.inc.php
+++ b/kona3engine/kona3parser_md.inc.php
@@ -515,7 +515,7 @@ function __kona3markdown_parser_tohtml(&$text, $level)
         if ($c1 == '`') {
             $text = mb_substr($text, 1);
             $s = kona3markdown_parser_token($text, "`");
-            $str = kona3markdown_parser_tohtml($s);
+            $str = htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
             $result .= "<span class='code'><code>$str</code></span>";
             continue;
         }
@@ -528,7 +528,7 @@ function __kona3markdown_parser_tohtml(&$text, $level)
             continue;
         }
         // strong2
-        if ($c2 == "__") {
+        if ($c2 == "__" && kona3markdown_param('md_underscore_emphasis', TRUE)) {
             $text = mb_substr($text, 2);
             $s = kona3markdown_parser_token($text, "__");
             $str = kona3markdown_parser_tohtml($s);

--- a/kona3engine/tests/kona3parser_md.test.php
+++ b/kona3engine/tests/kona3parser_md.test.php
@@ -52,3 +52,38 @@ $html = kona3markdown_parser_convert($text);
 
 test_assert(__LINE__, strpos($html, '<h1') !== false, "Markdown Mode: ■ translates to <h1> tag");
 test_assert(__LINE__, strpos($html, '<li>テストリスト') !== false, "Markdown Mode: ・ translates to <li> tag");
+
+// --- Inline Code and Underscore Emphasis Tests ---
+global $kona3conf;
+$orig_emphasis = isset($kona3conf['md_underscore_emphasis']) ? $kona3conf['md_underscore_emphasis'] : false;
+
+// 1. Test when md_underscore_emphasis is enabled (true)
+$kona3conf['md_underscore_emphasis'] = true;
+
+// Double underscore inside inline code should not trigger emphasis
+$text = "`__file__` and `__test__` code";
+$html = kona3markdown_parser_convert($text);
+test_assert(__LINE__, strpos($html, '<strong') === false, "Inside backticks, __ should not be styled as strong");
+test_assert(__LINE__, strpos($html, '<code>__file__</code>') !== false, "Inside backticks, __file__ should be displayed literally");
+
+// __emphasis__ should render as strong2
+$text = "This is __bold__ text";
+$html = kona3markdown_parser_convert($text);
+test_assert(__LINE__, strpos($html, "<strong class='strong2'>bold</strong>") !== false, "Enabled: __bold__ becomes strong2");
+
+// 2. Test when md_underscore_emphasis is disabled (false)
+$kona3conf['md_underscore_emphasis'] = false;
+
+// Double underscore inside inline code should not trigger emphasis
+$text = "`__file__` and `__test__` code";
+$html = kona3markdown_parser_convert($text);
+test_assert(__LINE__, strpos($html, '<strong') === false, "Inside backticks, __ should not be styled as strong");
+
+// __emphasis__ should NOT render as strong
+$text = "This is __bold__ text";
+$html = kona3markdown_parser_convert($text);
+test_assert(__LINE__, strpos($html, '<strong') === false, "Disabled: __bold__ should not become strong tag");
+test_assert(__LINE__, strpos($html, '__bold__') !== false, "Disabled: __bold__ should be literal");
+
+// Restore config
+$kona3conf['md_underscore_emphasis'] = $orig_emphasis;


### PR DESCRIPTION
Markdownで __file__ などの表記がインラインコード内で強調表示にならないように修正し、さらに __強調__ 自体を選択的に無効化できる設定項目 md_underscore_emphasis (デフォルト: false) を追加しました。