### PR TITLE
issue-231-security-update

### DIFF
--- a/kona3engine/kona3lib.inc.php
+++ b/kona3engine/kona3lib.inc.php
@@ -143,7 +143,7 @@ function kona3lib_execute()
     $actionFunc = "kona3_action_{$action}";
     $page = $kona3conf['page'];
     if (!file_exists($actionFile)) {
-        $action_html = htmlspecialchars($action);
+        $action_html = kona3htmlspecialchars($action);
         kona3error($page, "Invalid Action `$action_html`");
         exit;
     }
@@ -356,7 +356,7 @@ function kona3getRelativePath($wikiname)
 // show error page
 function kona3error($title, $msg)
 {
-    $title = htmlspecialchars($title);
+    $title = kona3htmlspecialchars($title);
     $err = "<div class='error_box'>" .
         "<h3 class='error'>$title</h3>" .
         "<div class='error pad'>$msg</div>" .
@@ -368,7 +368,7 @@ function kona3error($title, $msg)
 }
 function kona3showMessage($title, $msg, $tpl = '')
 {
-    $title = htmlspecialchars($title);
+    $title = kona3htmlspecialchars($title);
     $body = "<div>" .
         "<h3>$title</h3>" .
         "<div class='pad'>$msg</div>" .
@@ -533,6 +533,23 @@ function kona3getSkinURL($file, $use_mtime = FALSE)
 function kona3text2html($text)
 {
     return htmlentities($text, ENT_QUOTES, 'UTF-8');
+}
+
+function kona3htmlspecialchars($text)
+{
+    if (is_array($text)) {
+        $json = json_encode($text, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $text = ($json === false) ? '[Array]' : $json;
+    } else if (is_object($text)) {
+        if (method_exists($text, '__toString')) {
+            $text = (string)$text;
+        } else {
+            $text = '[Object:' . get_class($text) . ']';
+        }
+    } else if (is_resource($text)) {
+        $text = '[Resource]';
+    }
+    return htmlspecialchars((string)$text, ENT_QUOTES, 'UTF-8');
 }
 
 // filename to wikiname
@@ -908,7 +925,7 @@ function kona3getShortcutLink()
         $page = $_GET['page'];
     }
     $real_url = kona3getPageURL($page);
-    $page_h = htmlspecialchars($page, ENT_QUOTES);
+    $page_h = kona3htmlspecialchars($page);
     $res = "<a href=\"$real_url\">$page_h</a>";
 
     // エイリアスをチェックして表示する
@@ -917,8 +934,8 @@ function kona3getShortcutLink()
         if ($meta && isset($meta['aliases']) && is_array($meta['aliases']) && !empty($meta['aliases'])) {
             $aliases_h = [];
             foreach ($meta['aliases'] as $alias) {
-                $alias_h = htmlspecialchars($alias, ENT_QUOTES);
-                $url = htmlspecialchars(kona3getPageURL($alias), ENT_QUOTES);
+                $alias_h = kona3htmlspecialchars($alias);
+                $url = kona3htmlspecialchars(kona3getPageURL($alias));
                 $aliases_h[] = "<a href=\"$url\">$alias_h</a>";
             }
             $alias_label = lang('alias');
@@ -1128,8 +1145,8 @@ function kona3_getVersionupNotice()
     $exec_url = kona3getPageURL('', 'versionup', '', 'ver=3.3to3.4&write_token=' . urlencode($token));
     $cancel_url = kona3getPageURL('', 'versionup', '', 'ver=3.3to3.4&cmd=delete_msg&write_token=' . urlencode($token));
 
-    $exec_url_h = htmlspecialchars($exec_url, ENT_QUOTES, 'UTF-8');
-    $cancel_url_h = htmlspecialchars($cancel_url, ENT_QUOTES, 'UTF-8');
+    $exec_url_h = kona3htmlspecialchars($exec_url);
+    $cancel_url_h = kona3htmlspecialchars($cancel_url);
 
     $html = '
     <div style="background: linear-gradient(135deg, #fff3cd 0%, #ffeeba 100%); border: 1px solid #ffeeba; border-radius: 8px; padding: 15px 20px; margin: 15px auto; max-width: 900px; box-shadow: 0 4px 6px rgba(0,0,0,0.05); font-family: sans-serif; color: #856404; display: flex; align-items: center; justify-content: space-between; gap: 15px;">
@@ -1250,5 +1267,3 @@ function kona3git_commit_and_push($page, $edit_ext, $old_ext = '') {
         throw new Exception('Git Error:' . $e->getMessage());
     }
 }
-
-

--- a/kona3engine/kona3parser.inc.php
+++ b/kona3engine/kona3parser.inc.php
@@ -244,7 +244,7 @@ function konawiki_parser_render($tokens, $flag_isContents = TRUE)
         } else if ($cmd == "plugin") {
             $html .= konawiki_parser_render_plugin($value);
         } else if ($cmd == "conflict") {
-            $text = htmlspecialchars($text, ENT_QUOTES);
+            $text = kona3htmlspecialchars($text);
             if (trim($text) == "") {
                 $text = "&nbsp;";
             }
@@ -292,7 +292,7 @@ function konawiki_parser_render_hx(&$value)
         $all_text .= $konawiki_headers[$level] . "/";
     }
     $hash   = sprintf("%x", crc32($all_text));
-    $uri = htmlspecialchars(kona3getPageURL(), ENT_QUOTES) . "#h{$hash}";
+    $uri = kona3htmlspecialchars(kona3getPageURL()) . "#h{$hash}";
     $anchor = "<a id='h{$hash}' name='h{$hash}' href='$uri' class='anchor_super'>&nbsp;*</a>";
     $noanchor = konawiki_param("noanchor", FALSE) || konawiki_public('noanchor', FALSE);
     if ($noanchor) $anchor = "";
@@ -485,7 +485,7 @@ function __konawiki_parser_tohtml(&$text, $level)
                 $plugin['disable'] = '';
             }
             if ($plugin['disable'] || !file_exists($plugin["file"])) {
-                $result .= htmlspecialchars("&" . $pname . "(", ENT_QUITES);
+                $result .= kona3htmlspecialchars("&" . $pname . "(");
             } else {
                 $pparam = __konawiki_parser_tohtml($text, $level + 1);
                 $param_ary = explode(",", $pparam);
@@ -571,7 +571,7 @@ function konawiki_parser_tohtml($text)
 
 function konawiki_parser_tosource($src)
 {
-    $src = htmlspecialchars($src, ENT_QUOTES);
+    $src = kona3htmlspecialchars($src);
     return $src;
 }
 
@@ -603,7 +603,7 @@ function konawiki_parser_tosource_block($src)
         }
     }
     // no plugin
-    $src = htmlspecialchars($src, ENT_QUOTES);
+    $src = kona3htmlspecialchars($src);
     $begin = "<div><pre class='code'>";
     $end   = "</pre></div>" . $eol;
     return $begin . $src . $end;
@@ -612,8 +612,8 @@ function konawiki_parser_tosource_block($src)
 function konawiki_parser_makeUriLink($url)
 {
     $disp = mb_strimwidth($url, 0, 60, "..");
-    // $disp = htmlspecialchars($url);
-    $link = htmlspecialchars($url, ENT_QUOTES);
+    $disp = kona3htmlspecialchars($disp);
+    $link = konawiki_parser_checkURL($url, ['http', 'https', 'ftp', 'mailto']);
     return "<a href='$link'>$disp</a>";
 }
 
@@ -640,11 +640,12 @@ function konawiki_parser_makeWikiLink($name)
         $caption = trim($e[1]);
         $link    = trim($e[2]);
         // protocol ?
-        if ($caption == 'http' || $caption == 'https' || $caption == 'ftp') {
+        $caption_scheme = strtolower($caption);
+        if ($caption_scheme == 'http' || $caption_scheme == 'https' || $caption_scheme == 'ftp') {
             $link = $caption = $name;
         }
         // check all url
-        if (strpos($link, '://') !== FALSE) {
+        if (strpos($link, '://') !== FALSE || parse_url($link, PHP_URL_SCHEME) !== null) {
             // url
             $caption = konawiki_parser_disp_url($caption);
             $link = $link;
@@ -659,23 +660,28 @@ function konawiki_parser_makeWikiLink($name)
     }
 
     // check link
-    $link = konawiki_parser_checkURL($link);
+    $caption = konawiki_parser_tohtml($caption);
+    $link = konawiki_parser_checkURL($link, ['http', 'https', 'ftp']);
     return "<a href='$link'>$caption</a>";
 }
 
-function konawiki_parser_checkURL($url)
+function konawiki_parser_checkURL($url, $allowed_schemes = ['http', 'https'])
 {
-    // allow only http:// or https://
+    // allow relative URLs and known-safe schemes only.
     $url = trim($url);
-    if (preg_match('#^(.+?)\:(.*)$#', $url, $m)) {
-        if ($m[1] == 'http' || $m[1] == 'https') {
-            return htmlspecialchars($url, ENT_QUOTES);
+    $scheme = parse_url($url, PHP_URL_SCHEME);
+    if ($scheme !== null) {
+        $scheme = strtolower($scheme);
+        $allowed_schemes = array_map('strtolower', $allowed_schemes);
+        if (!in_array($scheme, $allowed_schemes, true)) {
+            $url = preg_replace('#[^a-zA-Z0-9_]#', '_', $url);
+            $url = "?WIKI_LINK_ERROR_" . $url;
         }
-        print_r("[{$m[1]}]");
+    } else if (preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*\s*:#', $url)) {
         $url = preg_replace('#[^a-zA-Z0-9_]#', '_', $url);
         $url = "?WIKI_LINK_ERROR_" . $url;
     }
-    $url = htmlspecialchars($url, ENT_QUOTES);
+    $url = kona3htmlspecialchars($url);
     return $url;
 }
 

--- a/kona3engine/kona3parser_md.inc.php
+++ b/kona3engine/kona3parser_md.inc.php
@@ -279,7 +279,7 @@ function kona3markdown_parser_render($tokens, $flag_isContents = TRUE)
             $html .= kona3markdown_parser_render_plugin($value);
         }
         else if ($cmd == "conflict") {
-            $text = htmlspecialchars($text, ENT_QUOTES);
+            $text = kona3htmlspecialchars($text);
             if (trim($text) == "") { $text = "&nbsp;"; }
             if ($value["flag"] == "[+]") {
                 $html .= "<div class='conflictadd'>+ $text</div>".$eol;
@@ -342,7 +342,7 @@ function kona3markdown_parser_render_hx(&$value)
         $all_text .= $kona3markdown_headers[$level]."/";
     }
     $hash   = sprintf("%x",crc32($all_text));
-    $uri = htmlspecialchars(kona3getPageURL(), ENT_QUOTES)."#h{$hash}";
+    $uri = kona3htmlspecialchars(kona3getPageURL())."#h{$hash}";
     $anchor = "<a id='h{$hash}' name='h{$hash}' href='$uri' class='anchor_super'>&nbsp;*</a>";
     $noanchor = kona3markdown_param("noanchor", FALSE) || kona3markdown_public('noanchor', FALSE);
     if ($noanchor) $anchor = "";
@@ -507,7 +507,7 @@ function __kona3markdown_parser_tohtml(&$text, $level)
         $c2 = mb_substr($text, 0, 2);
         // escape
         if ($c1 == '\\') {
-            $result .= mb_substr($text, 1, 1);
+            $result .= kona3htmlspecialchars(mb_substr($text, 1, 1));
             $text = mb_substr($text, 2);
             continue;
         }
@@ -515,7 +515,7 @@ function __kona3markdown_parser_tohtml(&$text, $level)
         if ($c1 == '`') {
             $text = mb_substr($text, 1);
             $s = kona3markdown_parser_token($text, "`");
-            $str = htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+            $str = kona3htmlspecialchars($s);
             $result .= "<span class='code'><code>$str</code></span>";
             continue;
         }
@@ -608,7 +608,7 @@ function kona3markdown_parser_tohtml($text)
 
 function kona3markdown_parser_tosource($src)
 {
-    $src = htmlspecialchars($src, ENT_QUOTES);
+    $src = kona3htmlspecialchars($src);
     return $src;
 }
 
@@ -647,12 +647,12 @@ function kona3markdown_parser_tosource_block($src, $params = [])
     }
     // no plugin
     $fname = $fileName;
-    $fname = htmlspecialchars($fname, ENT_QUOTES);
+    $fname = kona3htmlspecialchars($fname);
     if ($fname != '') {
         $css = 'font-size:0.7em; background-color:#f0f0f0; color:#909090; padding:2px;';
         $fname = "<div style='$css'>$fname</div>";
     }
-    $src = htmlspecialchars($src, ENT_QUOTES);
+    $src = kona3htmlspecialchars($src);
     $begin = "<div>$fname<pre class='code'>";
     $end   = "</pre></div>" . $eol;
     return $begin.$src.$end;
@@ -661,16 +661,16 @@ function kona3markdown_parser_tosource_block($src, $params = [])
 function kona3markdown_parser_makeUriLink($url)
 {
     $disp = mb_strimwidth($url, 0, 60, "..");
-    // $disp = htmlspecialchars($url);
-    $link = htmlspecialchars($url, ENT_QUOTES);
+    $disp = kona3htmlspecialchars($disp);
+    $link = kona3markdown_parser_checkURL($url, ['http', 'https', 'mailto']);
     return "<a href='$link'>$disp</a>";
 }
 
 function kona3markdown_parser_makeWikiLink($name, $linkto)
 {
-    $caption = $name;
+    $caption = kona3markdown_parser_tohtml($name);
     $link = $linkto;
-    if (strpos($link, '://') === FALSE) {
+    if (strpos($link, '://') === FALSE && parse_url($link, PHP_URL_SCHEME) === null) {
         // wiki link
         $link = kona3getPageURL($linkto);
     }
@@ -680,18 +680,23 @@ function kona3markdown_parser_makeWikiLink($name, $linkto)
     return "<a href='$link'>$caption</a>";
 }
 
-function kona3markdown_parser_checkURL($url)
+function kona3markdown_parser_checkURL($url, $allowed_schemes = ['http', 'https'])
 {
-    // allow only http:// or https://
+    // allow relative URLs and known-safe schemes only.
     $url = trim($url);
-    if (preg_match('#^(.+?)\:(.*)$#', $url, $m)) {
-        if ($m[1] == 'http' || $m[1] == 'https') {
-            return htmlspecialchars($url, ENT_QUOTES);
+    $scheme = parse_url($url, PHP_URL_SCHEME);
+    if ($scheme !== null) {
+        $scheme = strtolower($scheme);
+        $allowed_schemes = array_map('strtolower', $allowed_schemes);
+        if (!in_array($scheme, $allowed_schemes, true)) {
+            $url = preg_replace('#[^a-zA-Z0-9_]#', '_', $url);
+            $url = "?WIKI_LINK_ERROR_".$url;
         }
+    } else if (preg_match('#^[a-zA-Z][a-zA-Z0-9+\-.]*\s*:#', $url)) {
         $url = preg_replace('#[^a-zA-Z0-9_]#', '_', $url);
         $url = "?WIKI_LINK_ERROR_".$url;
     }
-    $url = htmlspecialchars($url, ENT_QUOTES);
+    $url = kona3htmlspecialchars($url);
     return $url;
 }
 

--- a/kona3engine/plugins/ref.inc.php
+++ b/kona3engine/plugins/ref.inc.php
@@ -52,24 +52,33 @@ function kona3plugins_ref_execute($args) {
         }
     }
     // make link
-    $caption = htmlspecialchars($caption, ENT_QUOTES);
-    $ext = pathinfo($url, PATHINFO_EXTENSION);
-    $url = htmlspecialchars_url($url);
-    if (!preg_match("#^https?\:\/\/#", $url)) {
+    $caption = kona3htmlspecialchars($caption);
+    $url_path = parse_url($rawurl, PHP_URL_PATH);
+    if ($url_path === null || $url_path === false) {
+        $url_path = $rawurl;
+    }
+    $ext = strtolower(pathinfo($url_path, PATHINFO_EXTENSION));
+    $url = kona3plugins_ref_external_url($rawurl);
+    if ($url === '') {
         // file link
-        $url2 = kona3plugins_ref_file_url($page, $url);
+        $url2 = kona3plugins_ref_file_url($page, $rawurl);
         if ($url2 === '') {
-            $url = htmlspecialchars($url, ENT_QUOTES);
+            $url = kona3plugins_ref_error_url($rawurl);
             return "<div class='error'>#ref({$url})</div>";
         }
-        $url = $url2;
+        $url = kona3htmlspecialchars($url2);
     }
     // Is image?
     $image_type = kona3getConf("image_pattern", "(jpg|jpeg|png|gif|ico|svg|webp)");
     $pattern = "#^($image_type)$#";
     if (preg_match($pattern, $ext)) {
         // image
-        if ($link == '') { $link = $url; }
+        if ($link != '') {
+            $link_safe = kona3plugins_ref_external_url($link);
+            $link = ($link_safe === '') ? $url : $link_safe;
+        } else {
+            $link = $url;
+        }
         $caph = "<div class='memo'>".$caption."</div>";
         $div = "<div>";
         if ($float) { $div = "<div {$float}>"; }
@@ -80,7 +89,7 @@ function kona3plugins_ref_execute($args) {
     } else {
         // not image
         if ($caption == "") {
-            $caption = htmlspecialchars($rawurl);
+            $caption = kona3htmlspecialchars($rawurl);
         }
         $code = "<div><a href='$url'>🔗{$caption}</a></div>";
     }
@@ -93,8 +102,12 @@ function kona3plugins_ref_file_url($page, $url) {
     $url = trim(str_replace('..', '', $url));
 
     // in attach_dir?
-    $f = kona3path_join($kona3conf["path.attach"], $url);
-    if (file_exists($f)) { return kona3path_join($kona3conf["url.attach"], $url); }
+    $attach_path = isset($kona3conf["path.attach"]) ? $kona3conf["path.attach"] : '';
+    $attach_url = isset($kona3conf["url.attach"]) ? $kona3conf["url.attach"] : '';
+    if ($attach_path !== '' && $attach_url !== '') {
+        $f = kona3path_join($attach_path, $url);
+        if (file_exists($f)) { return kona3path_join($attach_url, $url); }
+    }
 
     // check absolute file - Is this file in same directory?
     if (strpos($page, "/") !== FALSE) {
@@ -125,14 +138,21 @@ function kona3plugins_ref_file_url($page, $url) {
     return '';
 }
 
-function htmlspecialchars_url($xss){
-    $s = htmlspecialchars($xss, ENT_QUOTES, 'UTF-8');
-    $s = str_replace('http:','http<',$s);
-    $s = str_replace('https:','https<',$s);
-    $s = str_replace(':','',$s);
-    $s = str_replace(';','',$s);
-    $s = str_replace('http<','http:',$s);
-    $s = str_replace('https<','https:',$s);
-    return $s;
+function kona3plugins_ref_external_url($url) {
+    $url = trim($url);
+    $scheme = parse_url($url, PHP_URL_SCHEME);
+    if ($scheme === null || $scheme === false) {
+        return '';
+    }
+    $scheme = strtolower($scheme);
+    if ($scheme !== 'http' && $scheme !== 'https') {
+        return '';
+    }
+    return kona3htmlspecialchars($url);
 }
 
+function kona3plugins_ref_error_url($url) {
+    $url = trim($url);
+    $url = preg_replace('#^([a-zA-Z][a-zA-Z0-9+\-.]*)\s*:#', '$1_', $url);
+    return kona3htmlspecialchars($url);
+}

--- a/kona3engine/tests/kona3parser.test.php
+++ b/kona3engine/tests/kona3parser.test.php
@@ -115,6 +115,34 @@ $html = konawiki_parser_tohtml("<script>alert('xss')</script>");
 test_assert(__LINE__, strpos($html, '&lt;script&gt;') !== FALSE, "HTMLタグはエスケープされる");
 test_assert(__LINE__, strpos($html, '<script>') === FALSE, "<script>タグは実行されない");
 
+// --- セキュリティのテスト ---
+$html = konawiki_parser_convert("[[<img src=x onerror=alert(1)>]]", false);
+test_assert(__LINE__, strpos($html, '<img src=x') === false, "WikiLinkのページ名はHTMLタグを出力しない");
+test_assert(__LINE__, strpos($html, '&lt;img src=x onerror=alert(1)&gt;') !== false, "WikiLinkのページ名はテキストとして表示される");
+
+$html = konawiki_parser_convert("[[<img src=x onerror=alert(1)>:FrontPage]]", false);
+test_assert(__LINE__, strpos($html, '<img src=x') === false, "WikiLinkのキャプションはHTMLタグを出力しない");
+test_assert(__LINE__, strpos($html, '&lt;img src=x onerror=alert(1)&gt;') !== false, "WikiLinkのキャプションはテキストとして表示される");
+
+$html = konawiki_parser_convert("https://example.com/?a=1&b=2", false);
+test_assert(__LINE__, strpos($html, ">https://example.com/?a=1&amp;b=2</a>") !== false, "自動リンクの表示文字列はHTMLエスケープされる");
+
+$html = konawiki_parser_convert("[[bad:javascript:alert(1)]]", false);
+test_assert(__LINE__, strpos($html, 'javascript:') === false, "WikiLinkはjavascriptスキームを出力しない");
+test_assert(__LINE__, strpos($html, 'WIKI_LINK_ERROR') !== false, "拒否されたURLスキームはエラーリンクになる");
+
+$html = konawiki_parser_convert("&nosuchplugin(test);", false);
+test_assert(__LINE__, strpos($html, '&amp;nosuchplugin(test);') !== false, "存在しないインラインプラグインはFatal Errorにならずテキストとして出力される");
+
+global $kona3conf;
+$orig_plugin_disallow = isset($kona3conf['plugin.disallow']) ? $kona3conf['plugin.disallow'] : [];
+$kona3conf['plugin.disallow'] = ['counter' => true];
+$html = konawiki_parser_convert("#counter\n", false);
+test_assert(__LINE__, strpos($html, '[No Plugin:counter]') !== false, "無効化されたブロックプラグインは実行されない");
+$html = konawiki_parser_convert("&counter();", false);
+test_assert(__LINE__, strpos($html, '&amp;counter();') !== false, "無効化されたインラインプラグインは実行されない");
+$kona3conf['plugin.disallow'] = $orig_plugin_disallow;
+
 // --- 複雑な組み合わせのテスト ---
 $text = "■タイトル\nこれは段落です。\n\n・リスト1\n・リスト2\n|表|のセル|";
 $tokens = konawiki_parser_parse($text);

--- a/kona3engine/tests/kona3parser_md.test.php
+++ b/kona3engine/tests/kona3parser_md.test.php
@@ -53,6 +53,34 @@ $html = kona3markdown_parser_convert($text);
 test_assert(__LINE__, strpos($html, '<h1') !== false, "Markdown Mode: ■ translates to <h1> tag");
 test_assert(__LINE__, strpos($html, '<li>テストリスト') !== false, "Markdown Mode: ・ translates to <li> tag");
 
+// --- Security Rendering Tests ---
+$text = "\\<script\\>alert(1)\\</script\\>";
+$html = kona3markdown_parser_convert($text, false);
+test_assert(__LINE__, strpos($html, '<script>') === false, "Escaped angle brackets must not create script tags");
+test_assert(__LINE__, strpos($html, '&lt;script&gt;alert(1)&lt;/script&gt;') !== false, "Escaped angle brackets are rendered as text");
+
+$text = "[<img src=x onerror=alert(1)>](https://example.com)";
+$html = kona3markdown_parser_convert($text, false);
+test_assert(__LINE__, strpos($html, '<img src=x') === false, "Markdown link labels must escape HTML tags");
+test_assert(__LINE__, strpos($html, '&lt;img src=x onerror=alert(1)&gt;') !== false, "Markdown link labels keep escaped text");
+
+$text = "https://example.com/?a=1&b=<x>";
+$html = kona3markdown_parser_convert($text, false);
+test_assert(__LINE__, strpos($html, '>https://example.com/?a=1&amp;b=') !== false, "Auto-link display text escapes ampersands");
+
+$text = "[safe](HTTPS://example.com/?a=1&b=2)";
+$html = kona3markdown_parser_convert($text, false);
+test_assert(__LINE__, strpos($html, "href='HTTPS://example.com/?a=1&amp;b=2'") !== false, "URL scheme checks are case-insensitive for HTTPS");
+
+$text = "[bad](javascript:alert(1))";
+$html = kona3markdown_parser_convert($text, false);
+test_assert(__LINE__, strpos($html, 'javascript:') === false, "Markdown links must reject javascript scheme");
+test_assert(__LINE__, strpos($html, 'WIKI_LINK_ERROR') !== false, "Rejected schemes become link errors");
+
+$text = "![bad](javascript:alert(1))";
+$html = kona3markdown_parser_convert($text, false);
+test_assert(__LINE__, strpos($html, 'javascript:') === false, "Markdown images must not output javascript scheme");
+
 // --- Inline Code and Underscore Emphasis Tests ---
 global $kona3conf;
 $orig_emphasis = isset($kona3conf['md_underscore_emphasis']) ? $kona3conf['md_underscore_emphasis'] : false;

--- a/kona3engine/tests/ref.test.php
+++ b/kona3engine/tests/ref.test.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/test_common.inc.php';
+require_once dirname(__DIR__) . '/plugins/ref.inc.php';
+
+// --- #ref plugin security tests ---
+
+$html = kona3plugins_ref_execute([
+    'https://example.com/image.jpg?a=1&b=2',
+    '@javascript:alert(1)',
+    '*<b onclick=alert(1)>caption</b>',
+]);
+test_assert(__LINE__, strpos($html, 'javascript:') === false, '#ref: javascript link option is not output');
+test_assert(__LINE__, strpos($html, "href='https://example.com/image.jpg?a=1&amp;b=2'") !== false, '#ref: unsafe link option falls back to image URL');
+test_assert(__LINE__, strpos($html, "src='https://example.com/image.jpg?a=1&amp;b=2'") !== false, '#ref: image src URL is escaped');
+test_assert(__LINE__, strpos($html, '<b onclick=') === false, '#ref: caption HTML tag is not output');
+test_assert(__LINE__, strpos($html, '&lt;b onclick=alert(1)&gt;caption&lt;/b&gt;') !== false, '#ref: caption is escaped');
+
+$html = kona3plugins_ref_execute([
+    'https://example.com/image.jpg',
+    "@' onclick='alert(1)",
+]);
+test_assert(__LINE__, strpos($html, 'onclick=') === false, '#ref: quoted link option cannot inject attributes');
+test_assert(__LINE__, strpos($html, "href='https://example.com/image.jpg'") !== false, '#ref: invalid quoted link falls back to image URL');
+
+$html = kona3plugins_ref_execute([
+    'https://example.com/file.pdf?a=1&b=2',
+]);
+test_assert(__LINE__, strpos($html, "href='https://example.com/file.pdf?a=1&amp;b=2'") !== false, '#ref: non-image href URL is escaped');
+test_assert(__LINE__, strpos($html, 'https://example.com/file.pdf?a=1&amp;b=2') !== false, '#ref: non-image fallback caption is escaped');
+
+$html = kona3plugins_ref_execute([
+    'javascript:alert(1).jpg',
+]);
+test_assert(__LINE__, strpos($html, 'javascript:') === false, '#ref: unsafe image URL scheme is not output');
+test_assert(__LINE__, strpos($html, '#ref(javascript:alert') === false, '#ref: error output escapes unsafe URL');

--- a/kona3engine/tests/security.test.php
+++ b/kona3engine/tests/security.test.php
@@ -26,6 +26,32 @@ $escaped = kona3text2html('こんにちは<世界>');
 test_assert(__LINE__, strpos($escaped, 'こんにちは') !== FALSE, "XSS対策: 日本語はそのまま");
 test_assert(__LINE__, strpos($escaped, '&lt;世界&gt;') !== FALSE, "XSS対策: 日本語内のタグはエスケープ");
 
+// kona3htmlspecialchars() - 共通HTMLエスケープ関数
+$escaped = kona3htmlspecialchars('<script>alert("xss")</script>');
+test_assert(__LINE__, strpos($escaped, '&lt;script&gt;') !== FALSE, "共通HTMLエスケープ: <script>タグがエスケープされる");
+test_assert(__LINE__, strpos($escaped, '&quot;xss&quot;') !== FALSE, "共通HTMLエスケープ: ダブルクォートがエスケープされる");
+
+$escaped = kona3htmlspecialchars(null);
+test_eq(__LINE__, $escaped, '', "共通HTMLエスケープ: nullは空文字として扱う");
+
+$escaped = kona3htmlspecialchars(['tag' => '<b>', 'name' => '太郎']);
+test_assert(__LINE__, strpos($escaped, '&lt;b&gt;') !== FALSE, "共通HTMLエスケープ: 配列内のHTMLタグがエスケープされる");
+test_assert(__LINE__, strpos($escaped, '太郎') !== FALSE, "共通HTMLエスケープ: 配列内の日本語を保持する");
+
+class Kona3HtmlspecialcharsStringableForTest {
+    public function __toString()
+    {
+        return '<strong>ok</strong>';
+    }
+}
+$escaped = kona3htmlspecialchars(new Kona3HtmlspecialcharsStringableForTest());
+test_eq(__LINE__, $escaped, '&lt;strong&gt;ok&lt;/strong&gt;', "共通HTMLエスケープ: __toStringを持つオブジェクトをエスケープする");
+
+class Kona3HtmlspecialcharsObjectForTest {
+}
+$escaped = kona3htmlspecialchars(new Kona3HtmlspecialcharsObjectForTest());
+test_eq(__LINE__, $escaped, '[Object:Kona3HtmlspecialcharsObjectForTest]', "共通HTMLエスケープ: 文字列化できないオブジェクトは識別子にする");
+
 // --- パストラバーサル対策のテスト ---
 
 // kona3parseURI() でのパストラバーサル対策（再テスト）


### PR DESCRIPTION
## Summary
- Add a shared `kona3htmlspecialchars()` helper and route parser escaping through it.
- Harden KonaNotation and Markdown link rendering against stored XSS in link labels and escaped angle brackets.
- Replace parser URL scheme checks with explicit allow-list handling and add regression coverage for blocked schemes and disabled plugins.
- Harden `kona3htmlspecialchars()` for arrays, resources, and objects that cannot be safely cast to strings.
- Harden the `ref` plugin URL/caption escaping, including unsafe `@link` fallback and unsafe URL error display.

## Validation
- `just test` passed: 943/943

Closes #231