### PR TITLE
Fix #232: Enable horizontal scroll with gradient mask for footer menu on mobile

### DIFF
--- a/kona3engine/resource/kona3def.css
+++ b/kona3engine/resource/kona3def.css
@@ -1211,6 +1211,27 @@ ul.topnavi a
   font-size:0.6em;
   padding:12px;
   text-align:right;
+  line-height: 2em;
+}
+
+#wikifooter .footer_menu a
+{
+  margin: 4px;
+}
+
+@media screen and (max-width: 480px) {
+  #wikifooter .footer_menu {
+    text-align: center;
+    overflow-x: auto;
+    white-space: nowrap;
+    -webkit-overflow-scrolling: touch;
+    padding: 12px 6px;
+    -webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
+    mask-image: linear-gradient(to right, black 85%, transparent 100%);
+  }
+  #wikifooter .footer_menu a {
+    margin: 2px 4px;
+  }
 }
 
 #wikifooter .footer_menu > span

--- a/skin/single/kona3.css
+++ b/skin/single/kona3.css
@@ -92,6 +92,10 @@ body {
 	font-size: 0.6em;
 	text-align: right;
 	padding: 12px;
+	line-height: 2em;
+}
+#wikifooter .footer_menu a {
+	margin: 4px;
 }
 #wikifooter .footer_menu > span {
 	background-color: #f0f0f0;
@@ -1179,9 +1183,15 @@ span.konawiki3copyright a {
 	#wikifooter > div.footer_menu {
 		font-size: 24px;
 		text-align: center;
+		overflow-x: auto;
+		white-space: nowrap;
+		-webkit-overflow-scrolling: touch;
+		-webkit-mask-image: linear-gradient(to right, black 85%, transparent 100%);
+		mask-image: linear-gradient(to right, black 85%, transparent 100%);
 	}
 	#wikifooter a {
 		font-size: 20px;
+		margin: 2px 4px;
 	}
 	#loginform {
 		font-size: 28px;


### PR DESCRIPTION
Closes #232. Enabled horizontal scroll for the footer menu on mobile views and applied a gradient fade effect on the right edge.